### PR TITLE
web/nginx: shared volume (pvc - persistent volume claim)

### DIFF
--- a/invenio/templates/application.yaml
+++ b/invenio/templates/application.yaml
@@ -44,10 +44,10 @@ spec:
         command: [
           '/bin/bash',
           '-c',
-          'cp -R {{ .Values.web.statics.location }}/. /tmp/invenio/statics/']
+          'cp -R {{ .Values.web.assets.location }}/. /tmp/invenio/assets/']
         volumeMounts:
-            - name: "invenio-statics"
-              mountPath: "/tmp/invenio/statics/"
+            - name: "invenio-assets"
+              mountPath: "/tmp/invenio/assets/"
       containers:
       - name: web
         image: {{ .Values.web.image }}
@@ -112,8 +112,8 @@ spec:
         volumeMounts:
           - name: uwsgi-config
             mountPath: '/opt/invenio/src/uwsgi'
-          - name: "invenio-statics"
-            mountPath: "{{ .Values.web.statics.location }}"
+          - name: "invenio-assets"
+            mountPath: "{{ .Values.web.assets.location }}"
         resources:
           requests:
             memory: 200Mi
@@ -124,9 +124,9 @@ spec:
           configMap:
             defaultMode: 420
             name: uwsgi-config
-        - name: "invenio-statics"
+        - name: "invenio-assets"
           persistentVolumeClaim:
-            claimName: "invenio-statics-claim"
+            claimName: "invenio-assets-claim"
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/invenio/templates/application.yaml
+++ b/invenio/templates/application.yaml
@@ -38,6 +38,16 @@ spec:
       labels:
         app: web
     spec:
+      initContainers:
+      - name: web-init
+        image: {{ .Values.web.image }}
+        command: [
+          '/bin/bash',
+          '-c',
+          'cp -R {{ .Values.web.statics.location }}/. /tmp/invenio/statics/']
+        volumeMounts:
+            - name: "invenio-statics"
+              mountPath: "/tmp/invenio/statics/"
       containers:
       - name: web
         image: {{ .Values.web.image }}
@@ -84,7 +94,7 @@ spec:
               - -c
               - "uwsgi_curl $(hostname):5000 /ping -H 'Host: {{ .Values.host }}'"
           failureThreshold: 3
-          initialDelaySeconds: 15
+          initialDelaySeconds: 60
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
@@ -102,6 +112,8 @@ spec:
         volumeMounts:
           - name: uwsgi-config
             mountPath: '/opt/invenio/src/uwsgi'
+          - name: "invenio-statics"
+            mountPath: "{{ .Values.web.statics.location }}"
         resources:
           requests:
             memory: 200Mi
@@ -112,6 +124,10 @@ spec:
           configMap:
             defaultMode: 420
             name: uwsgi-config
+        - name: "invenio-statics"
+          persistentVolumeClaim:
+            claimName: "invenio-statics-claim"
+
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig

--- a/invenio/templates/configuration.yaml
+++ b/invenio/templates/configuration.yaml
@@ -74,6 +74,10 @@ data:
             uwsgi_param X-Forwarded-Proto $http_x_forwarded_proto;
             uwsgi_ignore_headers Set-Cookie;
         }
+        location /static {
+          alias /opt/invenio/var/instance/static/;
+          autoindex off;
+        }
     }
 ---
 apiVersion: v1

--- a/invenio/templates/services/nginx.yaml
+++ b/invenio/templates/services/nginx.yaml
@@ -43,8 +43,8 @@ spec:
             mountPath: /var/cache/nginx
           - name: var-log-nginx
             mountPath: /var/log/nginx
-          - name: "invenio-statics"
-            mountPath: "{{ .Values.web.statics.location }}"
+          - name: "invenio-assets"
+            mountPath: "{{ .Values.web.assets.location }}"
         readinessProbe:
           httpGet:
             path: /ping
@@ -89,9 +89,9 @@ spec:
         emptyDir: {}
       - name: var-log-nginx
         emptyDir: {}
-      - name: "invenio-statics"
+      - name: "invenio-assets"
         persistentVolumeClaim:
-          claimName: "invenio-statics-claim"
+          claimName: "invenio-assets-claim"
 
 {{ if .Values.logstash.enabled }}
 ---

--- a/invenio/templates/services/nginx.yaml
+++ b/invenio/templates/services/nginx.yaml
@@ -43,8 +43,8 @@ spec:
             mountPath: /var/cache/nginx
           - name: var-log-nginx
             mountPath: /var/log/nginx
-          - name: static
-            mountPath: /static
+          - name: "invenio-statics"
+            mountPath: "{{ .Values.web.statics.location }}"
         readinessProbe:
           httpGet:
             path: /ping
@@ -89,8 +89,9 @@ spec:
         emptyDir: {}
       - name: var-log-nginx
         emptyDir: {}
-      - name: static
-        emptyDir: {}
+      - name: "invenio-statics"
+        persistentVolumeClaim:
+          claimName: "invenio-statics-claim"
 
 {{ if .Values.logstash.enabled }}
 ---

--- a/invenio/templates/volumes.yaml
+++ b/invenio/templates/volumes.yaml
@@ -2,10 +2,10 @@
 apiVersion: "v1"
 kind: "PersistentVolumeClaim"
 metadata:
-  name: "invenio-statics-claim"
+  name: "invenio-assets-claim"
 spec:
   accessModes:
     - "ReadWriteMany"
   resources:
     requests:
-      storage: "10Gi"
+      storage: "{{ .Values.volume.assets.size }}"

--- a/invenio/templates/volumes.yaml
+++ b/invenio/templates/volumes.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  name: "invenio-statics-claim"
+spec:
+  accessModes:
+    - "ReadWriteMany"
+  resources:
+    requests:
+      storage: "10Gi"

--- a/invenio/values.yaml
+++ b/invenio/values.yaml
@@ -7,6 +7,8 @@ haproxy:
 nginx:
   max_conns: 100
   replicas: 2
+  statics:
+    location: /opt/invenio/var/instance/static
 
 web:
   image: your/invenio-image
@@ -20,7 +22,8 @@ web:
     scaler_cpu_utilization: 65
     max_web_replicas: 10
     min_web_replicas: 2
-
+  statics:
+    location: /opt/invenio/var/instance/static
 
 worker:
   enabled: true

--- a/invenio/values.yaml
+++ b/invenio/values.yaml
@@ -4,10 +4,13 @@ haproxy:
   inside_cluster: true
   maxconn: 100
 
+volume:
+  assets:
+    size: 10Gi
 nginx:
   max_conns: 100
   replicas: 2
-  statics:
+  assets:
     location: /opt/invenio/var/instance/static
 
 web:
@@ -22,7 +25,7 @@ web:
     scaler_cpu_utilization: 65
     max_web_replicas: 10
     min_web_replicas: 2
-  statics:
+  assets:
     location: /opt/invenio/var/instance/static
 
 worker:


### PR DESCRIPTION
Now Nginx and Web nodes share a volume (Persistent) for statics. However, it needs the image to have the statics (Addresse here https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/56).

Since volumes override the folder where they are being mounted (empty them). The web pod folder is "wiped out" of statics. To solve the issue an `initContainer` is launched, this will mount the volume in a temporary location and copy the statics to it. Therefore, it will be initialized with the correct statics. The copy of those is made to overwrite old ones, so there is no problem with future deployments.

The serving of statics has been off-loaded to nginx. Deeper consolidations are out of the scope of this PR, but will be addressed as part of https://github.com/inveniosoftware/helm-invenio/issues/7 and https://github.com/inveniosoftware/helm-invenio/issues/6.

In addition, at the moment the `initContainer` is launched once per pod. Which means that if there are 6 web pods the assets will be copied 6 times. This is not an issue since OpenShift provides a distributed locking system and all pod's assets are the same. This will be improved by adding nginx as a sidecar container and using an `emptyDir` instead of a volume. Will be treated in https://github.com/inveniosoftware/helm-invenio/issues/9 

Requires: https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/56