### PR TITLE
Make already existing secrets usable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .deploy
+.idea
+

--- a/invenio-k8s/templates/_helpers.tpl
+++ b/invenio-k8s/templates/_helpers.tpl
@@ -1,5 +1,45 @@
 {{/*
-Get the password secret.
+Get the redis host name.
+*/}}
+{{- define "redis.host_name" -}}
+{{- if .Values.redis.host }}
+    {{- printf "%s" (tpl .Values.redis.host $) -}}
+{{- else -}}
+    {{- `cache` -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the rabbitmq secret name.
+*/}}
+{{- define "rabbitmq.secret_name" -}}
+{{- if .Values.rabbitmq.existing_secret }}
+    {{- printf "%s" (tpl .Values.rabbitmq.existing_secret $) -}}
+{{- else -}}
+    {{- `mq-secrets` -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if we should use an existing secret for rabbitmq configuration.
+*/}}
+{{- define "rabbitmq.use_existing_secret" -}}
+{{- if .Values.postgresql.existing_secret -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a secret object should be created
+*/}}
+{{- define "rabbitmq.create_secret" -}}
+{{- if not (include "rabbitmq.use_existing_secret" .) -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the postgresql secret name.
 */}}
 {{- define "postgresql.secret_name" -}}
 {{- if .Values.postgresql.existing_secret }}
@@ -10,7 +50,7 @@ Get the password secret.
 {{- end -}}
 
 {{/*
-Return true if we should use an existingSecret.
+Return true if we should use an existing secret for postgresql configuration.
 */}}
 {{- define "postgresql.use_existing_secret" -}}
 {{- if .Values.postgresql.existing_secret -}}
@@ -19,10 +59,39 @@ Return true if we should use an existingSecret.
 {{- end -}}
 
 {{/*
-Return true if a secret object should be created
+Return true if a secret object should be created for postgresql configuration.
 */}}
 {{- define "postgresql.create_secret" -}}
 {{- if not (include "postgresql.use_existing_secret" .) -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the postgresql secret name.
+*/}}
+{{- define "elasticsearch.secret_name" -}}
+{{- if .Values.elasticsearch.existing_secret }}
+    {{- printf "%s" (tpl .Values.elasticsearch.existing_secret $) -}}
+{{- else -}}
+    {{- `elasticsearch-secrets` -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if we should use an existing secret for elasticsearch configuration.
+*/}}
+{{- define "elasticsearch.use_existing_secret" -}}
+{{- if .Values.elasticsearch.existing_secret -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a secret object should be created for elasticsearch configuration.
+*/}}
+{{- define "elasticsearch.create_secret" -}}
+{{- if not (include "elasticsearch.use_existing_secret" .) -}}
     {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/invenio-k8s/templates/_helpers.tpl
+++ b/invenio-k8s/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{/*
+Get the password secret.
+*/}}
+{{- define "postgresql.secret_name" -}}
+{{- if .Values.postgresql.existing_secret }}
+    {{- printf "%s" (tpl .Values.postgresql.existing_secret $) -}}
+{{- else -}}
+    {{- `"db-secrets"` -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if we should use an existingSecret.
+*/}}
+{{- define "postgresql.use_existing_secret" -}}
+{{- if .Values.postgresql.existing_secret -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a secret object should be created
+*/}}
+{{- define "postgresql.create_secret" -}}
+{{- if not (include "postgresql.use_existing_secret" .) -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/invenio-k8s/templates/_helpers.tpl
+++ b/invenio-k8s/templates/_helpers.tpl
@@ -5,7 +5,7 @@ Get the password secret.
 {{- if .Values.postgresql.existing_secret }}
     {{- printf "%s" (tpl .Values.postgresql.existing_secret $) -}}
 {{- else -}}
-    {{- `"db-secrets"` -}}
+    {{- `db-secrets` -}}
 {{- end -}}
 {{- end -}}
 

--- a/invenio-k8s/templates/application.yaml
+++ b/invenio-k8s/templates/application.yaml
@@ -1,10 +1,13 @@
 ---
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: invenio-ingress
   annotations:
+    {{- if .Values.ingress.class }}
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+    {{- end }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
@@ -78,30 +81,30 @@ spec:
           - name: INVENIO_BROKER_URL
             valueFrom:
               secretKeyRef:
-                name: mq-secrets
+                name: {{ include "rabbitmq.secret_name" . }}
                 key: CELERY_BROKER_URL
           - name: INVENIO_CELERY_BROKER_URL
             valueFrom:
               secretKeyRef:
-                name: mq-secrets
+                name: {{ include "rabbitmq.secret_name" . }}
                 key: CELERY_BROKER_URL
           - name: INVENIO_SQLALCHEMY_DATABASE_URI
             valueFrom:
               secretKeyRef:
-                name: db-secrets
+                name: {{ include "postgresql.secret_name" . }}
                 key: SQLALCHEMY_DB_URI
           - name: INVENIO_SECRET_KEY
             valueFrom:
               secretKeyRef:
                 name: invenio-secrets
                 key: INVENIO_SECRET_KEY
-          {{ if not .Values.elasticsearch.inside_cluster }}
+          {{- if not .Values.elasticsearch.inside_cluster }}
           - name: INVENIO_SEARCH_ELASTIC_HOSTS
             valueFrom:
               secretKeyRef:
-                name: elasticsearch-secrets
+                name: {{ include "elasticsearch.secret_name" . }}
                 key: INVENIO_SEARCH_ELASTIC_HOSTS
-          {{ end }}
+          {{- end }}
         readinessProbe:
           exec:
             command:
@@ -238,17 +241,17 @@ spec:
           - name: INVENIO_BROKER_URL
             valueFrom:
               secretKeyRef:
-                name: mq-secrets
+                name: {{ include "rabbitmq.secret_name" . }}
                 key: CELERY_BROKER_URL
           - name: INVENIO_CELERY_BROKER_URL
             valueFrom:
               secretKeyRef:
-                name: mq-secrets
+                name: {{ include "rabbitmq.secret_name" . }}
                 key: CELERY_BROKER_URL
           - name: INVENIO_SQLALCHEMY_DATABASE_URI
             valueFrom:
               secretKeyRef:
-                name: db-secrets
+                name: {{ include "postgresql.secret_name" . }}
                 key: SQLALCHEMY_DB_URI
           - name: INVENIO_SECRET_KEY
             valueFrom:
@@ -259,7 +262,7 @@ spec:
           - name: INVENIO_SEARCH_ELASTIC_HOSTS
             valueFrom:
               secretKeyRef:
-                name: elasticsearch-secrets
+                name: {{  include "elasticsearch.secret_name" . }}
                 key: INVENIO_SEARCH_ELASTIC_HOSTS
           {{ end }}
         resources:

--- a/invenio-k8s/templates/application.yaml
+++ b/invenio-k8s/templates/application.yaml
@@ -1,6 +1,10 @@
 ---
 {{- if .Values.ingress.enabled -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: invenio-ingress

--- a/invenio-k8s/templates/configuration.yaml
+++ b/invenio-k8s/templates/configuration.yaml
@@ -124,6 +124,8 @@ data:
 
   INVENIO_ACCOUNTS_SESSION_REDIS_URL: 'redis://cache:6379/1'
   INVENIO_APP_ALLOWED_HOSTS: '[''{{ .Values.host }}'']'
+  INVENIO_SITE_UI_URL: '{{ .Values.host }}'
+  INVENIO_SITE_API_URL: '{{ .Values.host }}/api'
   INVENIO_CACHE_REDIS_HOST: 'cache'
   INVENIO_CACHE_REDIS_URL: 'redis://cache:6379/0'
   INVENIO_CELERY_RESULT_BACKEND: 'redis://cache:6379/2'

--- a/invenio-k8s/templates/configuration.yaml
+++ b/invenio-k8s/templates/configuration.yaml
@@ -73,6 +73,7 @@ data:
             uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
             uwsgi_param X-Forwarded-Proto $http_x_forwarded_proto;
             uwsgi_ignore_headers Set-Cookie;
+            client_max_body_size {{ .Values.nginx.client_max_body_size }};
         }
         location /static {
           alias "{{ .Values.nginx.assets.location }}";
@@ -121,16 +122,15 @@ kind: ConfigMap
 metadata:
   name: invenio-config
 data:
-
-  INVENIO_ACCOUNTS_SESSION_REDIS_URL: 'redis://cache:6379/1'
+  INVENIO_ACCOUNTS_SESSION_REDIS_URL: 'redis://{{ include "redis.host_name" . }}:6379/1'
   INVENIO_APP_ALLOWED_HOSTS: '[''{{ .Values.host }}'']'
   INVENIO_SITE_UI_URL: '{{ .Values.host }}'
   INVENIO_SITE_API_URL: '{{ .Values.host }}/api'
-  INVENIO_CACHE_REDIS_HOST: 'cache'
-  INVENIO_CACHE_REDIS_URL: 'redis://cache:6379/0'
-  INVENIO_CELERY_RESULT_BACKEND: 'redis://cache:6379/2'
+  INVENIO_CACHE_REDIS_HOST: '{{ include "redis.host_name" . }}'
+  INVENIO_CACHE_REDIS_URL: 'redis://{{ include "redis.host_name" . }}:6379/0'
+  INVENIO_CELERY_RESULT_BACKEND: 'redis://{{ include "redis.host_name" . }}:6379/2'
   INVENIO_COLLECT_STORAGE: flask_collect.storage.file
-  INVENIO_RATELIMIT_STORAGE_URL: 'redis://cache:6379/3'
+  INVENIO_RATELIMIT_STORAGE_URL: 'redis://{{ include "redis.host_name" . }}:6379/3'
   {{ if .Values.elasticsearch.inside_cluster }}
   INVENIO_SEARCH_ELASTIC_HOSTS: "{{ .Values.elasticsearch.invenio_hosts }}"
   {{ end }}

--- a/invenio-k8s/templates/secrets.yaml
+++ b/invenio-k8s/templates/secrets.yaml
@@ -1,16 +1,18 @@
 ---
+{{- if (include "rabbitmq.create_secret" .) }}
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: mq-secrets
+  name: {{  include "rabbitmq.secret_name" . }}
   labels:
-    app: mq-secrets
+    app: {{  include "rabbitmq.secret_name" . }}
 data:
   RABBITMQ_DEFAULT_PASS: {{ .Values.rabbitmq.default_password | b64enc }}
   CELERY_BROKER_URL: {{ .Values.rabbitmq.celery_broker_uri | b64enc }}
 
 ---
+{{- end -}}
 {{- if (include "postgresql.create_secret" .) }}
 apiVersion: v1
 kind: Secret
@@ -18,7 +20,7 @@ type: Opaque
 metadata:
   name: {{  include "postgresql.secret_name" . }}
   labels:
-    app: db-secrets
+    app: {{  include "postgresql.secret_name" . }}
 data:
   POSTGRESQL_USER: {{ .Values.postgresql.user | b64enc }}
   POSTGRESQL_PASSWORD: {{ .Values.postgresql.password | b64enc }}
@@ -29,19 +31,21 @@ data:
 
 ---
 {{- end -}}
+{{- if (include "elasticsearch.create_secret" .) }}
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: elasticsearch-secrets
+  name: {{  include "elasticsearch.secret_name" . }}
   labels:
-    app: elasticsearch-secrets
+    app: {{  include "elasticsearch.secret_name" . }}
 data:
   ELASTICSEARCH_USER: {{ .Values.elasticsearch.user | b64enc }}
   ELASTICSEARCH_PASSWORD: {{ .Values.elasticsearch.password | b64enc }}
   INVENIO_SEARCH_ELASTIC_HOSTS: {{ .Values.elasticsearch.invenio_hosts | b64enc }}
 
 ---
+{{- end -}}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/invenio-k8s/templates/secrets.yaml
+++ b/invenio-k8s/templates/secrets.yaml
@@ -10,13 +10,13 @@ data:
   RABBITMQ_DEFAULT_PASS: {{ .Values.rabbitmq.default_password | b64enc }}
   CELERY_BROKER_URL: {{ .Values.rabbitmq.celery_broker_uri | b64enc }}
 
-{{- if (include "postgresql.create_secret" .) }}
 ---
+{{- if (include "postgresql.create_secret" .) }}
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: db-secrets
+  name: {{  include "postgresql.secret_name" . }}
   labels:
     app: db-secrets
 data:
@@ -26,9 +26,9 @@ data:
   POSTGRESQL_PORT: {{ .Values.postgresql.port | b64enc }}
   POSTGRESQL_DATABASE: {{ .Values.postgresql.database | b64enc }}
   SQLALCHEMY_DB_URI: {{ .Values.postgresql.sqlalchemy_db_uri | b64enc }}
-{{- end -}}
 
 ---
+{{- end -}}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/invenio-k8s/templates/secrets.yaml
+++ b/invenio-k8s/templates/secrets.yaml
@@ -10,6 +10,7 @@ data:
   RABBITMQ_DEFAULT_PASS: {{ .Values.rabbitmq.default_password | b64enc }}
   CELERY_BROKER_URL: {{ .Values.rabbitmq.celery_broker_uri | b64enc }}
 
+{{- if (include "postgresql.create-secret" .) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -25,7 +26,7 @@ data:
   POSTGRESQL_PORT: {{ .Values.postgresql.port | b64enc }}
   POSTGRESQL_DATABASE: {{ .Values.postgresql.database | b64enc }}
   SQLALCHEMY_DB_URI: {{ .Values.postgresql.sqlalchemy_db_uri | b64enc }}
-
+{{- end -}}
 ---
 apiVersion: v1
 kind: Secret

--- a/invenio-k8s/templates/secrets.yaml
+++ b/invenio-k8s/templates/secrets.yaml
@@ -27,6 +27,7 @@ data:
   POSTGRESQL_DATABASE: {{ .Values.postgresql.database | b64enc }}
   SQLALCHEMY_DB_URI: {{ .Values.postgresql.sqlalchemy_db_uri | b64enc }}
 {{- end -}}
+
 ---
 apiVersion: v1
 kind: Secret

--- a/invenio-k8s/templates/secrets.yaml
+++ b/invenio-k8s/templates/secrets.yaml
@@ -10,7 +10,7 @@ data:
   RABBITMQ_DEFAULT_PASS: {{ .Values.rabbitmq.default_password | b64enc }}
   CELERY_BROKER_URL: {{ .Values.rabbitmq.celery_broker_uri | b64enc }}
 
-{{- if (include "postgresql.create-secret" .) }}
+{{- if (include "postgresql.create_secret" .) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/invenio-k8s/templates/services/elasticsearch.yaml
+++ b/invenio-k8s/templates/services/elasticsearch.yaml
@@ -32,10 +32,10 @@ spec:
         - containerPort: 9200
         resources:
           requests:
-            cpu: 1
+            cpu: "1"
             memory: 512Mi
           limits:
-            cpu: 2
+            cpu: "2"
             memory: 1Gi
         env:
         - name: TZ

--- a/invenio-k8s/templates/services/postgresql.yaml
+++ b/invenio-k8s/templates/services/postgresql.yaml
@@ -34,13 +34,19 @@ spec:
         - name: TZ
           value: "Europe/Zurich"
         - name: POSTGRESQL_USER
-          value: invenio
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "postgresql.secret_name" . }}
+              key: POSTGRESQL_USER
         - name: POSTGRESQL_DATABASE
-          value: invenio
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "postgresql.secret_name" . }}
+              key: POSTGRESQL_DATABASE
         - name: POSTGRESQL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: db-secrets
+              name: {{  include "postgresql.secret_name" . }}
               key: POSTGRESQL_PASSWORD
         volumeMounts:
           - name: data

--- a/invenio-k8s/templates/services/rabbitmq.yaml
+++ b/invenio-k8s/templates/services/rabbitmq.yaml
@@ -43,7 +43,7 @@ spec:
         - name: RABBITMQ_DEFAULT_PASS
           valueFrom:
             secretKeyRef:
-              name: mq-secrets
+              name: {{  include "rabbitmq.secret_name" . }}
               key: RABBITMQ_DEFAULT_PASS
         readinessProbe:
           exec:

--- a/invenio-k8s/values.yaml
+++ b/invenio-k8s/values.yaml
@@ -60,7 +60,7 @@ postgresql:
   inside_cluster: true
   user: "invenio"
   password: "db_password"
-  existing_secret: ""
+  existing_secret: "db-secrets"
   host: "db"
   port: "5432"
   database: "invenio"

--- a/invenio-k8s/values.yaml
+++ b/invenio-k8s/values.yaml
@@ -60,7 +60,7 @@ postgresql:
   inside_cluster: true
   user: "invenio"
   password: "db_password"
-  existing_secret: "db-secrets"
+  existing_secret: ""
   host: "db"
   port: "5432"
   database: "invenio"

--- a/invenio-k8s/values.yaml
+++ b/invenio-k8s/values.yaml
@@ -18,6 +18,7 @@ haproxy:
 
 nginx:
   max_conns: 100
+  client_max_body_size: 50G
   assets:
     location: /opt/invenio/var/instance/static
 
@@ -50,17 +51,20 @@ worker:
 
 redis:
   inside_cluster: true
+  # The following must be set if inside_cluster is 'false'
+  host: ""
 
 rabbitmq:
   inside_cluster: true
+  existing_secret: ""
   default_password: "mq_password"
   celery_broker_uri: "amqp://guest:mq_password@mq:5672/"
 
 postgresql:
   inside_cluster: true
+  existing_secret: ""
   user: "invenio"
   password: "db_password"
-  existing_secret: ""
   host: "db"
   port: "5432"
   database: "invenio"
@@ -68,6 +72,7 @@ postgresql:
 
 elasticsearch:
   inside_cluster: true
+  existing_secret: ""
   invenio_hosts: "[{'host': 'es'}]"
   user: "username"  # unimplemented
   password: "password"  # unimplemented

--- a/invenio-k8s/values.yaml
+++ b/invenio-k8s/values.yaml
@@ -60,6 +60,7 @@ postgresql:
   inside_cluster: true
   user: "invenio"
   password: "db_password"
+  existing_secret: ""
   host: "db"
   port: "5432"
   database: "invenio"


### PR DESCRIPTION
I added the ability to use existing secrets to the vanilla kubernetes chart. The redis hostname is now configurable as well to make it possible to use a self-managed deployment. The possibility to define the max upload size was addded, too.