### PR TITLE
global: add sentry and remote applications support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,25 @@ Parameter | Description | Default
 `invenio.default_users` | If set, create users identified by email:password on install (only works if init=true) | `nil`
 `invenio.demo_data` | Whether to create demo data on install (only works if init=true and if `default_users` isn't empty) | `false`
 `logging.console.level` | Console logging level | `WARNING`
+`logging.sentry.enabled` | Enable Sentry logging | `false`
+`logging.sentry.existing_secret` | Whether to use an existing secret or create a new one | `false`
+`logging.sentry.secret_name` | Name of the secret to use or create | `sentry-secrets`
+`logging.sentry.dsn` | DSN for sentry | `""`
 `logging.sentry.level` | Sentry logging level | `WARNING`
 `logging.sentry.celery` | Configure Celery to send logging to Sentry | `true`
 `logging.sentry.environment` | Sentry environment | `qa`
 `search.index_prefix` | Elasticsearch index prefix | `""`
 `datacite.enable` | Enable DataCite provider | `false`
+`datacite.existing_secret` | Whether to use an existing secret or create a new one | `false`
+`datacite.secret_name` | Name of the secret to use or create | `remote-apps-secrets`
 `datacite.prefix` | DataCite prefix | `""`
+`datacite.username` | DataCite username | `""`
+`datacite.password` | DataCite password | `""`
+`datacite.test_mode` | When using testing mode requests will be done against DataCite's test fabrica | `""`
+`remote_apps.enabled` | Enable logging with remote applications | `false`
+`remote_apps.existing_secret` | Whether to use an existing secret or create a new one | `false`
+`remote_apps.secret_name` | Name of the secret to use or create | `remote-apps-secrets`
+`remote_apps.credentials` | List of remote applications' credentials (name, consume_key, consumer_secret) | `""`
 
 ### HAProxy
 Parameter | Description | Default

--- a/benchmark/locustfile.py
+++ b/benchmark/locustfile.py
@@ -29,7 +29,7 @@ If you need to run an specific set of tests:
   $ firefox http://127.0.0.1:8089
 """
 
-from locust import HttpLocust, TaskSet, task, between
+from locust import HttpUser, TaskSet, task, between
 
 # The recid to query is not randomized because without caching
 # there is no difference. When having a different recid queried the output
@@ -116,13 +116,13 @@ class APIRecordsTaskSet(TaskSet):
     def api_search_random(self):
         """API Random search."""
         params = {'q': SEARCH_QUERY}
-        self.client.get('/api/records/', params=params)
+        self.client.get('/api/records', params=params)
 
 
     @task
     def api_search_full(self):
         """API Random search."""
-        self.client.get('/api/records/')
+        self.client.get('/api/records')
 
     # @task
     # def api_search_malformed(self):
@@ -180,21 +180,21 @@ class UserTaskSet(TaskSet):
     pass
 
 
-class UIRecords(HttpLocust):
-    task_set = UIRecordsTaskSet
+class UIRecords(HttpUser):
+    tasks = [UIRecordsTaskSet]
     wait_time = between(1.0, 2.0)
 
 
-class APIRecords(HttpLocust):
-    task_set = APIRecordsTaskSet
+class APIRecords(HttpUser):
+    tasks = [APIRecordsTaskSet]
     wait_time = between(1.0, 2.0)
 
 
-class Files(HttpLocust):
-    task_set = FilesTaskSet
+class Files(HttpUser):
+    tasks = [FilesTaskSet]
     wait_time = between(1.0, 2.0)
 
 
-class User(HttpLocust):
-    task_set = UserTaskSet
+class User(HttpUser):
+    tasks = [UserTaskSet]
     wait_time = between(1.0, 2.0)

--- a/invenio/templates/configurations/invenio.yaml
+++ b/invenio/templates/configurations/invenio.yaml
@@ -10,17 +10,21 @@ data:
   INVENIO_CACHE_REDIS_URL: 'redis://{{ include "redis.host_name" . }}:6379/0'
   INVENIO_CELERY_RESULT_BACKEND: 'redis://{{ include "redis.host_name" . }}:6379/2'
   INVENIO_COLLECT_STORAGE: flask_collect.storage.file
+  INVENIO_DATACITE_ENABLED: "{{ .Values.invenio.datacite.enabled }}"
+  {{ if .Values.invenio.datacite.enabled }}
+  INVENIO_DATACITE_PREFIX: "{{ .Values.invenio.datacite.prefix }}"
+  INVENIO_DATACITE_TEST_MODE: "{{ .Values.invenio.datacite.test_mode }}"
+  {{ end }}
   INVENIO_LOGGING_CONSOLE_LEVEL: "{{ .Values.invenio.logging.console.level }}"
   INVENIO_LOGGING_SENTRY_CELERY: "{{ .Values.invenio.logging.sentry.celery }}"
   INVENIO_LOGGING_SENTRY_LEVEL: "{{ .Values.invenio.logging.sentry.level }}"
   INVENIO_RATELIMIT_STORAGE_URL: 'redis://{{ include "redis.host_name" . }}:6379/3'
-  INVENIO_RDM_RECORDS_DATACITE_ENABLED: "{{ .Values.invenio.datacite.enable }}"
-  INVENIO_RDM_RECORDS_DATACITE_PREFIX: "{{ .Values.invenio.datacite.prefix }}"
   {{ if .Values.elasticsearch.enabled }}
   INVENIO_SEARCH_ELASTIC_HOSTS: "{{ .Values.elasticsearch.invenio_hosts }}"
   {{ end }}
   INVENIO_SEARCH_INDEX_PREFIX: "{{ .Values.invenio.search.index_prefix }}"
-  INVENIO_SITE_UI_URL: '{{ .Values.host }}'
-  INVENIO_SITE_API_URL: '{{ .Values.host }}/api'
+  INVENIO_SITE_HOSTNAME: '{{ .Values.host }}'
+  INVENIO_SITE_UI_URL: 'https://{{ .Values.host }}'
+  INVENIO_SITE_API_URL: 'https://{{ .Values.host }}/api'
   SENTRY_ENVIRONMENT: "{{ .Values.invenio.logging.sentry.environment }}"
   

--- a/invenio/templates/configurations/secrets.yaml
+++ b/invenio/templates/configurations/secrets.yaml
@@ -7,6 +7,8 @@ metadata:
   name: {{ .Values.rabbitmq.secret_name }}
   labels:
     app: {{ .Values.rabbitmq.secret_name }}
+  annotations:
+    helm.sh/resource-policy: keep
 data:
   RABBITMQ_DEFAULT_PASS: {{ .Values.rabbitmq.default_password | b64enc }}
   CELERY_BROKER_URL: {{ .Values.rabbitmq.celery_broker_uri | b64enc }}
@@ -21,6 +23,8 @@ metadata:
   name: {{ .Values.postgresql.secret_name }}
   labels:
     app: {{ .Values.postgresql.secret_name }}
+  annotations:
+    helm.sh/resource-policy: keep
 data:
   POSTGRESQL_USER: {{ .Values.postgresql.user | b64enc }}
   POSTGRESQL_PASSWORD: {{ .Values.postgresql.password | b64enc }}
@@ -39,10 +43,44 @@ metadata:
   name: {{ .Values.elasticsearch.secret_name }}
   labels:
     app: {{ .Values.elasticsearch.secret_name }}
+  annotations:
+    helm.sh/resource-policy: keep
 data:
   ELASTICSEARCH_USER: {{ .Values.elasticsearch.user | b64enc }}
   ELASTICSEARCH_PASSWORD: {{ .Values.elasticsearch.password | b64enc }}
   INVENIO_SEARCH_ELASTIC_HOSTS: {{ .Values.elasticsearch.invenio_hosts | b64enc }}
+
+---
+{{- end -}}
+{{- if and (.Values.invenio.logging.sentry.enabled) (not .Values.invenio.logging.sentry.existing_secret) }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.invenio.logging.sentry.secret_name }}
+  labels:
+    app: {{ .Values.invenio.logging.sentry.secret_name }}
+  annotations:
+    helm.sh/resource-policy: keep
+data:
+  SENTRY_DSN: {{ .Values.invenio.logging.sentry.dsn | b64enc }}
+
+---
+{{- end -}}
+{{- if and (.Values.invenio.remote_apps.enabled) (not .Values.invenio.remote_apps.existing_secret) }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.invenio.remote_apps.secret_name }}
+  labels:
+    app: {{ .Values.invenio.remote_apps.secret_name }}
+  annotations:
+    helm.sh/resource-policy: keep
+data:
+  {{- range .Values.invenio.remote_apps.credentials }}
+  {{ default (printf "INVENIO_%s_APP_CREDENTIALS" .name) }}: {{ printf "{\"consumer_key\": \"%s\" , \"consumer_secret\": \"%s\"}" .consumer_key .consumer_secret | b64enc }}
+  {{- end }}
 
 ---
 {{- end -}}
@@ -54,6 +92,24 @@ metadata:
   name: invenio-secrets
   labels:
     app: invenio-secrets
+  annotations:
+    helm.sh/resource-policy: keep
 data:
   INVENIO_SECRET_KEY: {{ .Values.invenio.secret_key | b64enc }}
+
+---
+{{- end -}}
+{{- if and (.Values.invenio.datacite.enabled) (not .Values.invenio.datacite.existing_secret)}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: datacite-secrets
+  labels:
+    app: datacite-secrets
+  annotations:
+    helm.sh/resource-policy: keep
+data:
+  DATACITE_PASSWORD: {{ .Values.invenio.datacite.password | b64enc }}
+  DATACITE_USERNAME: {{ .Values.invenio.datacite.user | b64enc }}
 {{- end -}}

--- a/invenio/templates/deployments/rabbitmq.yaml
+++ b/invenio/templates/deployments/rabbitmq.yaml
@@ -35,6 +35,13 @@ spec:
                 secretKeyRef:
                   name: {{  .Values.rabbitmq.secret_name }}
                   key: RABBITMQ_DEFAULT_PASS
+          resources:
+            limits:
+              cpu: '1'
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
           readinessProbe:
             exec:
               command:

--- a/invenio/templates/deployments/web.yaml
+++ b/invenio/templates/deployments/web.yaml
@@ -62,6 +62,34 @@ spec:
               name: {{ .Values.elasticsearch.secret_name }}
               key: INVENIO_SEARCH_ELASTIC_HOSTS
         {{- end }}
+        {{- if .Values.invenio.logging.sentry.enabled }}
+        - name: INVENIO_SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.invenio.logging.sentry.secret_name }}
+              key: SENTRY_DSN
+        {{- end }}
+        {{- if .Values.invenio.datacite.enabled }}
+        - name: DATACITE_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.invenio.datacite.secret_name }}
+              key: DATACITE_USERNAME
+        - name: DATACITE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.invenio.datacite.secret_name }}
+              key: DATACITE_PASSWORD
+        {{- end }}
+        {{- if .Values.invenio.remote_apps.enabled }}
+        {{- range .Values.invenio.remote_apps.credentials }}
+        - name: {{ default (printf "INVENIO_%s_APP_CREDENTIALS" .name) }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Values.invenio.remote_apps.secret_name }}
+              key: {{ default (printf "INVENIO_%s_APP_CREDENTIALS" .name) }}
+        {{- end }}
+        {{- end }}
         readinessProbe:
           exec:
             command:

--- a/invenio/templates/deployments/web.yaml
+++ b/invenio/templates/deployments/web.yaml
@@ -119,9 +119,11 @@ spec:
           mountPath: /opt/nginx-invenio-assets
         resources:
           requests:
-            memory: 200Mi
+              cpu: 500m
+              memory: 200Mi
           limits:
-            memory: 1Gi
+              cpu: '1'
+              memory: 1Gi
         {{- if .Values.web.imagePullSecret }}
         imagePullSecrets:
         - name: {{ .Values.web.imagePullSecret }}

--- a/invenio/templates/deployments/worker.yaml
+++ b/invenio/templates/deployments/worker.yaml
@@ -61,14 +61,33 @@ spec:
               name: {{ .Values.elasticsearch.secret_name }}
               key: INVENIO_SEARCH_ELASTIC_HOSTS
         {{- end }}
+        {{- if .Values.invenio.logging.sentry.enabled }}
+        - name: INVENIO_SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.invenio.logging.sentry.secret_name }}
+              key: SENTRY_DSN
+        {{- end }}
+        {{- if .Values.invenio.datacite.enabled }}
+        - name: DATACITE_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.invenio.datacite.secret_name }}
+              key: DATACITE_USERNAME
+        - name: DATACITE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.invenio.datacite.secret_name }}
+              key: DATACITE_PASSWORD
+        {{- end }}
         livenessProbe:
           exec:
             command:
               - /bin/bash
               - -c
-              - "celery inspect ping -d celery@$(hostname) -A {{ .Values.worker.app }}"
-          initialDelaySeconds: 15
-          timeoutSeconds: 10
+              - "celery -A {{ .Values.worker.app }} inspect ping -d celery@$(hostname)"
+          initialDelaySeconds: 20
+          timeoutSeconds: 30
         resources:
           requests:
             memory: 200Mi

--- a/invenio/templates/deployments/worker.yaml
+++ b/invenio/templates/deployments/worker.yaml
@@ -90,8 +90,10 @@ spec:
           timeoutSeconds: 30
         resources:
           requests:
-            memory: 200Mi
+            cpu: 500m
+            memory: 500Mi
           limits:
+            cpu: '1'
             memory: 1Gi
       {{- if .Values.worker.imagePullSecret }}
       imagePullSecrets:

--- a/invenio/values.yaml
+++ b/invenio/values.yaml
@@ -20,14 +20,31 @@ invenio:
     console:
       level: "WARNING"
     sentry:
+      enabled: false
+      existing_secret: false
+      secret_name: "sentry-secrets"
+      dsn: ""
       level: "WARNING"
       celery: true
       environment: "qa"
   search:
     index_prefix: ""
   datacite:
-    enable: false
+    enabled: false
+    existing_secret: false
+    secret_name: "datacite-secrets"
+    password: ""
+    username: ""
     prefix: ""
+    test_mode: true
+  remote_apps:
+    enabled: false
+    existing_secret: false
+    secret_name: "remote-apps-secrets"
+    credentials:
+      - name: ""
+        consumer_key: ""
+        consumer_secret: ""
 
 haproxy:
   enabled: true


### PR DESCRIPTION
Add support for:
- Sentry
- Remote app auth. Zenodo is planning on setting ORCiD, GitHub and AAI.

Fixes some minor configuration issues with secrets, workers and rabbitmq.

When merged open tickets to add support for:
- Kibana
- Flower
- PGadmin
- Sentry