### PR TITLE
nginx: added robots.txt rule

### DIFF
--- a/invenio/templates/configurations/nginx.yaml
+++ b/invenio/templates/configurations/nginx.yaml
@@ -112,4 +112,10 @@ data:
           alias "{{ .Values.nginx.assets.location }}";
           autoindex off;
         }
+
+        # Robots.txt file is served by nginx.
+        location /robots.txt {
+          alias {{ .Values.nginx.assets.location }}/robots.txt;
+          autoindex off;
+        }
     }


### PR DESCRIPTION
closes https://github.com/inveniosoftware/helm-invenio/issues/47

Notes:

- file `robots.txt` was [added](https://github.com/inveniosoftware/invenio-app-rdm/commit/cb5bd39104c8a40ef98a18b3b7c42d7da877e08d) in `invenio-app-rdm` and will only be available for images whose version of `invenio-app-rdm` were upgraded.