### PR TITLE
Explicitly set boolean values with their python literals

### DIFF
--- a/invenio/templates/configurations/invenio.yaml
+++ b/invenio/templates/configurations/invenio.yaml
@@ -12,10 +12,14 @@ data:
   INVENIO_COLLECT_STORAGE: flask_collect.storage.file
   {{ if .Values.invenio.datacite.enabled }}
   INVENIO_DATACITE_PREFIX: "{{ .Values.invenio.datacite.prefix }}"
-  INVENIO_DATACITE_TEST_MODE: "{{ .Values.invenio.datacite.test_mode }}"
   INVENIO_DATACITE_ENABLED: "True"
   {{ else }}
   INVENIO_DATACITE_ENABLED: "False"
+  {{ end }}
+  {{ if .Values.invenio.datacite.test_mode }}
+  INVENIO_DATACITE_TEST_MODE: "True"
+  {{ else }}
+  INVENIO_DATACITE_TEST_MODE: "False"
   {{ end }}
   INVENIO_LOGGING_CONSOLE_LEVEL: "{{ .Values.invenio.logging.console.level }}"
   INVENIO_LOGGING_SENTRY_CELERY: "{{ .Values.invenio.logging.sentry.celery }}"

--- a/invenio/templates/configurations/invenio.yaml
+++ b/invenio/templates/configurations/invenio.yaml
@@ -10,10 +10,12 @@ data:
   INVENIO_CACHE_REDIS_URL: 'redis://{{ include "redis.host_name" . }}:6379/0'
   INVENIO_CELERY_RESULT_BACKEND: 'redis://{{ include "redis.host_name" . }}:6379/2'
   INVENIO_COLLECT_STORAGE: flask_collect.storage.file
-  INVENIO_DATACITE_ENABLED: "{{ .Values.invenio.datacite.enabled }}"
   {{ if .Values.invenio.datacite.enabled }}
   INVENIO_DATACITE_PREFIX: "{{ .Values.invenio.datacite.prefix }}"
   INVENIO_DATACITE_TEST_MODE: "{{ .Values.invenio.datacite.test_mode }}"
+  INVENIO_DATACITE_ENABLED: "True"
+  {{ else }}
+  INVENIO_DATACITE_ENABLED: "False"
   {{ end }}
   INVENIO_LOGGING_CONSOLE_LEVEL: "{{ .Values.invenio.logging.console.level }}"
   INVENIO_LOGGING_SENTRY_CELERY: "{{ .Values.invenio.logging.sentry.celery }}"


### PR DESCRIPTION
closes https://github.com/inveniosoftware/helm-invenio/issues/53

This is just a workaround - since invenio is evaluating the environment variables as Python literals, those should NOT used as YAML guard variables in the helm charts, or every "false" value will be evaluated to true leading to misconfigurations