### PR TITLE
configurations: support invenio config injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,30 +57,18 @@ Parameter | Description | Default
 `invenio.init` | Whether to initiate database, index and roles | `false`
 `invenio.default_users` | If set, create users identified by email:password on install (only works if init=true) | `nil`
 `invenio.demo_data` | Whether to create demo data on install (only works if init=true and if `default_users` isn't empty) | `false`
-`invenio.logging.console.level` | Console logging level | `WARNING`
-`invenio.logging.sentry.enabled` | Enable Sentry logging | `false`
-`invenio.logging.sentry.existing_secret` | Whether to use an existing secret or create a new one | `false`
-`invenio.logging.sentry.secret_name` | Name of the secret to use or create | `sentry-secrets`
-`invenio.logging.sentry.dsn` | DSN for sentry | `""`
-`invenio.logging.sentry.level` | Sentry logging level | `WARNING`
-`invenio.logging.sentry.celery` | Configure Celery to send logging to Sentry | `true`
-`invenio.logging.sentry.environment` | Sentry environment | `qa`
-`invenio.mail.suppress` | Suppress (`true`) or allow (`false` sending e-mails | `true`
-`invenio.mail.server` | Mail server hostname | `""`
-`invenio.mail.port` | Mail server port | `25`
-`invenio.mail.sender` | Mail sender | `""`
-`invenio.search.index_prefix` | Search index prefix | `""`
+`invenio.sentry.enabled` | Enable Sentry logging | `false`
+`invenio.sentry.existing_secret` | Whether to use an existing secret or create a new one | `false`
+`invenio.sentry.secret_name` | Name of the secret to use or create | `sentry-secrets`
+`invenio.sentry.dsn` | DSN for sentry | `""`
 `invenio.datacite.enable` | Enable DataCite provider | `false`
 `invenio.datacite.existing_secret` | Whether to use an existing secret or create a new one | `false`
 `invenio.datacite.secret_name` | Name of the secret to use or create | `datacite-secrets`
-`invenio.datacite.prefix` | DataCite prefix | `""`
-`invenio.datacite.username` | DataCite username | `""`
-`invenio.datacite.password` | DataCite password | `""`
-`invenio.datacite.test_mode` | When using testing mode requests will be done against DataCite's test fabrica | `""`
 `invenio.remote_apps.enabled` | Enable logging with remote applications | `false`
 `invenio.remote_apps.existing_secret` | Whether to use an existing secret or create a new one | `false`
 `invenio.remote_apps.secret_name` | Name of the secret to use or create | `remote-apps-secrets`
 `invenio.remote_apps.credentials` | List of remote applications' credentials (name, consume_key, consumer_secret) | `""`
+`invenio.extra_config` | List of key:value configuration variables accepted by the python application | `""`
 
 ### HAProxy
 Parameter | Description | Default

--- a/invenio/templates/configurations/invenio.yaml
+++ b/invenio/templates/configurations/invenio.yaml
@@ -9,31 +9,11 @@ data:
   INVENIO_CACHE_REDIS_HOST: '{{ include "redis.host_name" . }}'
   INVENIO_CACHE_REDIS_URL: 'redis://{{ include "redis.host_name" . }}:6379/0'
   INVENIO_CELERY_RESULT_BACKEND: 'redis://{{ include "redis.host_name" . }}:6379/2'
-  INVENIO_COLLECT_STORAGE: flask_collect.storage.file
-  {{ if .Values.invenio.datacite.enabled }}
-  INVENIO_DATACITE_PREFIX: "{{ .Values.invenio.datacite.prefix }}"
-  INVENIO_DATACITE_ENABLED: "True"
-  {{ else }}
-  INVENIO_DATACITE_ENABLED: "False"
-  {{ end }}
-  {{ if .Values.invenio.datacite.test_mode }}
-  INVENIO_DATACITE_TEST_MODE: "True"
-  {{ else }}
-  INVENIO_DATACITE_TEST_MODE: "False"
-  {{ end }}
-  INVENIO_LOGGING_CONSOLE_LEVEL: "{{ .Values.invenio.logging.console.level }}"
-  INVENIO_LOGGING_SENTRY_CELERY: "{{ .Values.invenio.logging.sentry.celery }}"
-  INVENIO_LOGGING_SENTRY_LEVEL: "{{ .Values.invenio.logging.sentry.level }}"
-  INVENIO_MAIL_NOTIFY_SENDER: "{{ .Values.invenio.mail.sender }}"
-  INVENIO_MAIL_SUPPRESS_SEND: "{{ .Values.invenio.mail.suppress }}"
-  INVENIO_MAIL_SERVER: "{{ .Values.invenio.mail.server }}"
-  INVENIO_MAIL_PORT: "{{ .Values.invenio.mail.port }}"
   INVENIO_RATELIMIT_STORAGE_URL: 'redis://{{ include "redis.host_name" . }}:6379/3'
-  {{ if .Values.search.enabled }}
   INVENIO_SEARCH_HOSTS: "{{ .Values.search.invenio_hosts }}"
-  {{ end }}
-  INVENIO_SEARCH_INDEX_PREFIX: "{{ .Values.invenio.search.index_prefix }}"
   INVENIO_SITE_HOSTNAME: '{{ .Values.host }}'
   INVENIO_SITE_UI_URL: 'https://{{ .Values.host }}'
   INVENIO_SITE_API_URL: 'https://{{ .Values.host }}/api'
-  SENTRY_ENVIRONMENT: "{{ .Values.invenio.logging.sentry.environment }}"
+  {{- range $key, $value := .Values.invenio.extra_config }}
+  {{ $key }}: {{ $value | toYaml | indent 4 | trim }}
+  {{- end }}

--- a/invenio/templates/configurations/secrets.yaml
+++ b/invenio/templates/configurations/secrets.yaml
@@ -52,18 +52,18 @@ data:
 
 ---
 {{- end -}}
-{{- if and (.Values.invenio.logging.sentry.enabled) (not .Values.invenio.logging.sentry.existing_secret) }}
+{{- if and (.Values.invenio.sentry.enabled) (not .Values.invenio.sentry.existing_secret) }}
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ .Values.invenio.logging.sentry.secret_name }}
+  name: {{ .Values.invenio.sentry.secret_name }}
   labels:
-    app: {{ .Values.invenio.logging.sentry.secret_name }}
+    app: {{ .Values.invenio.sentry.secret_name }}
   annotations:
     helm.sh/resource-policy: keep
 data:
-  SENTRY_DSN: {{ .Values.invenio.logging.sentry.dsn | b64enc }}
+  SENTRY_DSN: {{ .Values.invenio.sentry.dsn | b64enc }}
 
 ---
 {{- end -}}

--- a/invenio/templates/deployments/web.yaml
+++ b/invenio/templates/deployments/web.yaml
@@ -72,11 +72,11 @@ spec:
               name: {{ .Values.search.secret_name }}
               key: INVENIO_SEARCH_HOSTS
         {{- end }}
-        {{- if .Values.invenio.logging.sentry.enabled }}
+        {{- if .Values.invenio.sentry.enabled }}
         - name: INVENIO_SENTRY_DSN
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.invenio.logging.sentry.secret_name }}
+              name: {{ .Values.invenio.sentry.secret_name }}
               key: SENTRY_DSN
         {{- end }}
         {{- if .Values.invenio.datacite.enabled }}

--- a/invenio/templates/deployments/worker.yaml
+++ b/invenio/templates/deployments/worker.yaml
@@ -71,11 +71,11 @@ spec:
               name: {{ .Values.search.secret_name }}
               key: INVENIO_SEARCH_HOSTS
         {{- end }}
-        {{- if .Values.invenio.logging.sentry.enabled }}
+        {{- if .Values.invenio.sentry.enabled }}
         - name: INVENIO_SENTRY_DSN
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.invenio.logging.sentry.secret_name }}
+              name: {{ .Values.invenio.sentry.secret_name }}
               key: SENTRY_DSN
         {{- end }}
         {{- if .Values.invenio.datacite.enabled }}
@@ -197,11 +197,11 @@ spec:
               name: {{ .Values.search.secret_name }}
               key: INVENIO_SEARCH_HOSTS
         {{- end }}
-        {{- if .Values.invenio.logging.sentry.enabled }}
+        {{- if .Values.invenio.sentry.enabled }}
         - name: INVENIO_SENTRY_DSN
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.invenio.logging.sentry.secret_name }}
+              name: {{ .Values.invenio.sentry.secret_name }}
               key: SENTRY_DSN
         {{- end }}
         {{- if .Values.invenio.datacite.enabled }}

--- a/invenio/values.yaml
+++ b/invenio/values.yaml
@@ -15,32 +15,15 @@ invenio:
   # the variables below requires init=true
   default_users: # email:password
   demo_data: false # requires default_users
-  logging:
-    console:
-      level: "WARNING"
-    sentry:
-      enabled: false
-      existing_secret: false
-      secret_name: "sentry-secrets"
-      dsn: ""
-      level: "WARNING"
-      celery: true
-      environment: "qa"
-  mail:
-    suppress: true
-    server: ""
-    port: 25
-    sender: ""
-  search:
-    index_prefix: ""
+  sentry:
+    enabled: false
+    existing_secret: false
+    secret_name: "sentry-secrets"
+    dsn: ""
   datacite:
     enabled: false
     existing_secret: false
     secret_name: "datacite-secrets"
-    password: ""
-    username: ""
-    prefix: ""
-    test_mode: true
   remote_apps:
     enabled: false
     existing_secret: false
@@ -49,6 +32,11 @@ invenio:
       - name: ""
         consumer_key: ""
         consumer_secret: ""
+  extra_config:
+    INVENIO_COLLECT_STORAGE: "flask_collect.storage.file"
+    INVENIO_DATACITE_ENABLED: "False"
+    INVENIO_LOGGING_CONSOLE_LEVEL: "WARNING"
+    INVENIO_SEARCH_INDEX_PREFIX: ""
 
 haproxy:
   enabled: true


### PR DESCRIPTION
- closes https://github.com/zenodo/zenodo-rdm/issues/113
- example: https://gitlab.cern.ch/zenodo/zenodo-rdm-openshift/-/merge_requests/1

Helm Charts do not accept injecting external files, as a security feature. We could still have the values in different files, but given that the way of injecting them would be the same we might as well just have one `values.yaml` file.