### PR TITLE
celery beat: remove worker need from liveness probe

### DIFF
--- a/invenio/templates/deployments/worker.yaml
+++ b/invenio/templates/deployments/worker.yaml
@@ -221,7 +221,7 @@ spec:
             command:
               - /bin/bash
               - -c
-              - "celery -A {{ .Values.worker.app }} inspect ping -d celery@$(hostname)"
+              - "celery -A {{ .Values.worker.app }} inspect ping"
           initialDelaySeconds: 20
           timeoutSeconds: 30
         {{- if .Values.worker.resources }}


### PR DESCRIPTION
`-d` is used to check for worker node names, but now beat has no worker
