### PR TITLE
deployments: added resources to redis and mq.

### DIFF
--- a/invenio/templates/deployments/rabbitmq.yaml
+++ b/invenio/templates/deployments/rabbitmq.yaml
@@ -42,13 +42,9 @@ spec:
                 secretKeyRef:
                   name: {{  .Values.rabbitmq.secret_name }}
                   key: RABBITMQ_DEFAULT_PASS
-          resources:
-            limits:
-              cpu: '1'
-              memory: 2Gi
-            requests:
-              cpu: 500m
-              memory: 500Mi
+          {{- if .Values.rabbitmq.resources }}
+            resources: {{- toYaml .Values.rabbitmq.resources | nindent 10 }}
+          {{- end }}
           readinessProbe:
             exec:
               command:

--- a/invenio/templates/deployments/redis.yaml
+++ b/invenio/templates/deployments/redis.yaml
@@ -45,4 +45,7 @@ spec:
                 - "redis-cli -h $(hostname) ping"
             initialDelaySeconds: 15
             timeoutSeconds: 5
+      {{- if .Values.redis.resources }}
+        resources: {{- toYaml .Values.redis.resources | nindent 10 }}
+      {{- end }}
 {{- end -}}

--- a/invenio/values.yaml
+++ b/invenio/values.yaml
@@ -155,6 +155,13 @@ redis:
     access_mode: ReadWriteMany
     size: 5G
     storage_class: ""
+  resources:
+    limits:
+      cpu: '1'
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 500Mi
 
 rabbitmq:
   enabled: true
@@ -169,6 +176,13 @@ rabbitmq:
     access_mode: ReadWriteMany
     size: 10G
     storage_class: ""
+  resources:
+    limits:
+      cpu: '1'
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 500Mi
 
 postgresql:
   enabled: false


### PR DESCRIPTION
closes https://github.com/zenodo/zenodo-rdm/issues/524


Redis and MQ resources were not configurable, on Zenodo-RDM we have to be able to tweak them on deployment.