### PR TITLE
deployment: Changing deploymentconfigs by deployment. Adding filebeat…

### DIFF
--- a/invenio/templates/deployments/haproxy.yaml
+++ b/invenio/templates/deployments/haproxy.yaml
@@ -1,21 +1,14 @@
 {{- if .Values.haproxy.enabled -}}
 ---
-{{- if .Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig" }}
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
-{{- else }}
 apiVersion: apps/v1
 kind: Deployment
-{{- end }}
 metadata:
   name: haproxy
 spec:
   replicas: 1
-  {{- if not (.Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig") }}
   selector:
     matchLabels:
       app: haproxy
-  {{- end }}
   template:
     metadata:
       labels:

--- a/invenio/templates/deployments/opensearch.yaml
+++ b/invenio/templates/deployments/opensearch.yaml
@@ -2,22 +2,15 @@
 # See <https://opensearch.org/docs/latest/opensearch/install/helm/> instead.
 {{- if .Values.search.enabled -}}
 ---
-{{- if .Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig" }}
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
-{{- else }}
 apiVersion: apps/v1
 kind: Deployment
-{{- end }}
 metadata:
   name: search
 spec:
   replicas: 1
-  {{- if not (.Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig") }}
   selector:
     matchLabels:
       app: search
-  {{- end }}
   template:
     metadata:
       labels:

--- a/invenio/templates/deployments/postgresql.yaml
+++ b/invenio/templates/deployments/postgresql.yaml
@@ -1,21 +1,14 @@
 {{- if .Values.postgresql.enabled -}}
 ---
-{{- if .Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig" }}
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
-{{- else }}
 apiVersion: apps/v1
 kind: Deployment
-{{- end }}
 metadata:
   name: db
 spec:
   replicas: 1
-  {{- if not (.Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig") }}
   selector:
     matchLabels:
       app: db
-  {{- end }}
   template:
     metadata:
       labels:

--- a/invenio/templates/deployments/rabbitmq.yaml
+++ b/invenio/templates/deployments/rabbitmq.yaml
@@ -1,21 +1,14 @@
 {{- if .Values.rabbitmq.enabled -}}
 ---
-{{- if .Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig" }}
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
-{{- else }}
 apiVersion: apps/v1
 kind: Deployment
-{{- end }}
 metadata:
   name: mq
 spec:
   replicas: 1
-  {{- if not (.Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig") }}
   selector:
     matchLabels:
       app: mq
-  {{- end }}
   template:
     metadata:
       labels:

--- a/invenio/templates/deployments/redis.yaml
+++ b/invenio/templates/deployments/redis.yaml
@@ -1,21 +1,14 @@
 {{- if .Values.redis.enabled -}}
 ---
-{{- if .Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig" }}
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
-{{- else }}
 apiVersion: apps/v1
 kind: Deployment
-{{- end }}
 metadata:
   name: cache
 spec:
   replicas: 1
-  {{- if not (.Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig") }}
   selector:
     matchLabels:
       app: cache
-  {{- end }}
   template:
     metadata:
       labels:

--- a/invenio/templates/deployments/web.yaml
+++ b/invenio/templates/deployments/web.yaml
@@ -1,20 +1,13 @@
 ---
-{{- if .Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig" }}
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
-{{- else }}
 apiVersion: apps/v1
 kind: Deployment
-{{- end }}
 metadata:
   name: web
 spec:
   replicas: {{ .Values.web.replicas }}
-  {{- if not (.Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig") }}
   selector:
     matchLabels:
       app: web
-  {{- end }}
   template:
     metadata:
       labels:
@@ -179,12 +172,9 @@ spec:
             "-c", "/etc/filebeat.yml",
             "-e",
         ]
-        resources:
-          limits:
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
+        {{- if .Values.logstash.filebeat_resources }}
+        resources: {{- toYaml .Values.logstash.filebeat_resources | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /etc/filebeat.yml

--- a/invenio/templates/deployments/worker.yaml
+++ b/invenio/templates/deployments/worker.yaml
@@ -1,20 +1,13 @@
 ---
-{{- if .Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig" }}
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
-{{- else }}
 apiVersion: apps/v1
 kind: Deployment
-{{- end }}
 metadata:
   name: worker
 spec:
   replicas: {{ .Values.worker.replicas }}
-  {{- if not (.Capabilities.APIVersions.Has "apps.openshift.io/v1/DeploymentConfig") }}
   selector:
     matchLabels:
       app: worker
-  {{- end }}
   template:
     metadata:
       labels:

--- a/invenio/values.yaml
+++ b/invenio/values.yaml
@@ -208,6 +208,12 @@ search:
 logstash:
   enabled: false
   filebeat_image: "docker.elastic.co/beats/filebeat-oss:8.10.2"
+  filebeat_resources:
+    limits:
+      memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
   logstash_image: "docker.elastic.co/logstash/logstash-oss:8.10.2"
   environment: "qa"
   cern_monit:


### PR DESCRIPTION
… resources to the values

:heart: Thank you for your contribution!

### Description

Changing the deploymentconfigs by deployment. Tested in zenodo-rdm-qa


Most of the things went smoothly. A couple of small hiccups:
* haproxy does not restart with configuration changes. It needs a rollout. Usually, there are not many changes here, so it might be ok
* Same forweb, with changes in the invenio.cfg
* There is one deploymentconfig left, worker_beat. According to the annotations, it comes from helm, although I do not see it in the current version. Should we  just delete that deploymentconfig?