### PR TITLE
Move docstart markers to start of secrets

### DIFF
--- a/invenio/templates/configurations/secrets.yaml
+++ b/invenio/templates/configurations/secrets.yaml
@@ -1,5 +1,5 @@
----
 {{- if not (.Values.rabbitmq.existing_secret) }}
+---
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -13,9 +13,9 @@ data:
   RABBITMQ_DEFAULT_PASS: {{ .Values.rabbitmq.default_password | b64enc }}
   CELERY_BROKER_URL: {{ .Values.rabbitmq.celery_broker_uri | b64enc }}
 
----
 {{- end -}}
 {{- if not (.Values.flower.existing_secret) }}
+---
 {{- $credentials := printf "flower:%s" .Values.flower.default_password }}
 apiVersion: v1
 kind: Secret
@@ -29,9 +29,9 @@ metadata:
 data:
   FLOWER_BASIC_AUTH_CREDENTIALS: {{ $credentials | b64enc}}
 
----
 {{- end -}}
 {{- if not (.Values.postgresql.existing_secret) }}
+---
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -49,9 +49,9 @@ data:
   POSTGRESQL_DATABASE: {{ .Values.postgresql.database | b64enc }}
   SQLALCHEMY_DB_URI: {{ .Values.postgresql.sqlalchemy_db_uri | b64enc }}
 
----
 {{- end -}}
 {{- if not (.Values.search.existing_secret) }}
+---
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -66,9 +66,9 @@ data:
   SEARCH_PASSWORD: {{ .Values.search.password | b64enc }}
   INVENIO_SEARCH_HOSTS: {{ .Values.search.invenio_hosts | b64enc }}
 
----
 {{- end -}}
 {{- if and (.Values.invenio.sentry.enabled) (not .Values.invenio.sentry.existing_secret) }}
+---
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -81,9 +81,9 @@ metadata:
 data:
   SENTRY_DSN: {{ .Values.invenio.sentry.dsn | b64enc }}
 
----
 {{- end -}}
 {{- if and (.Values.invenio.remote_apps.enabled) (not .Values.invenio.remote_apps.existing_secret) }}
+---
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -98,9 +98,9 @@ data:
   {{ default (printf "INVENIO_%s_APP_CREDENTIALS" .name) }}: {{ printf "{\"consumer_key\": \"%s\" , \"consumer_secret\": \"%s\"}" .consumer_key .consumer_secret | b64enc }}
   {{- end }}
 
----
 {{- end -}}
 {{- if not (.Values.invenio.existing_secret) }}
+---
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -115,9 +115,9 @@ data:
   INVENIO_SECURITY_LOGIN_SALT: {{ .Values.invenio.security_login_salt | b64enc }}
   INVENIO_CSRF_SECRET_SALT: {{ .Values.invenio.csrf_secret_salt | b64enc }}
 
----
 {{- end -}}
 {{- if and (.Values.invenio.datacite.enabled) (not .Values.invenio.datacite.existing_secret)}}
+---
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -135,6 +135,7 @@ data:
 {{- if .Values.invenio.extra_secrets }}
 {{- range $key, $value := .Values.invenio.extra_secrets }}
 {{- if and ($value.enabled) (not $value.existing_secret)}}
+---
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -151,5 +152,4 @@ data:
 {{- end }}
 {{- end }}
 
----
 {{- end -}}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This change moves the YAML document start markers (`---`) to the start of Secrets instead of at the end.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
