### PR TITLE
Set securityContext for compliance with PSS "restricted"

### DIFF
--- a/charts/invenio/templates/flower/deployment.yaml
+++ b/charts/invenio/templates/flower/deployment.yaml
@@ -29,6 +29,11 @@ spec:
               ]
           ports:
             - containerPort: 5555
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: TZ
               value: {{ required "Missing .Values.global.timezone" .Values.global.timezone }}
@@ -45,6 +50,12 @@ spec:
               mountPath: /var/celery
             - name: flower-config-volume
               mountPath: /var/flower
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: "RuntimeDefault"
       volumes:
         - name: celery-config-volume
           configMap:

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -126,6 +126,11 @@ spec:
           - name: kerberos-credentials-cache
             mountPath: /tmp
           {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       - name: nginx
         image: {{ .Values.nginx.image }}
         env:
@@ -190,7 +195,11 @@ spec:
           - name: kerberos-credentials-cache
             mountPath: /tmp
       {{- end }}
-
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       initContainers:
         # copy assets from uwsgi to nginx
         - name: copy-web-assets
@@ -207,6 +216,11 @@ spec:
             requests:
               cpu: '1'
               memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: nginx-invenio-assets
               mountPath: /opt/nginx-invenio-assets
@@ -223,7 +237,12 @@ spec:
             - name: kerberos-credentials-cache
               mountPath: /tmp
         {{- end }}
-
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: "RuntimeDefault"
       volumes:
       {{- if .Values.logstash.enabled }}
       - name: config

--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -21,6 +21,11 @@ spec:
           "-c",
           "celery -A {{ .Values.worker.app }} beat -l {{ .Values.worker.log_level }} -s {{ .Values.worker.celery_schedule }} --pidfile {{ .Values.worker.celery_pidfile }}"
         ]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
         - name: var-run-celery
           mountPath: {{ .Values.worker.run_mount_path }}
@@ -100,6 +105,12 @@ spec:
             cpu: '2'
             memory: 500Mi
         {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: "RuntimeDefault"
       volumes:
       - name: var-run-celery
         emptyDir:

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -24,6 +24,11 @@ spec:
           {{- if .Values.worker.resources }}
           resources: {{- toYaml .Values.worker.resources | nindent 12 }}
           {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           envFrom:
             - configMapRef:
                 name: invenio-config
@@ -136,7 +141,12 @@ spec:
             - name: kerberos-credentials-cache
               mountPath: /tmp
       {{- end }}
-
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: "RuntimeDefault"
       volumes:
         {{- if .Values.persistence.enabled }}
         - name: shared-volume

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -225,6 +225,8 @@ postgresqlExternal: {}
 
 opensearch:
   enabled: true
+  sysctlImage:
+    enabled: false
 
 externalOpensearch: {}
 


### PR DESCRIPTION
### Description

This change makes the `worker-beat` pod compliant with the Pod Security Standard "restricted". For more information, please see: <https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted>

There are still a handful of policy violations left:

```
W0212 13:13:00.741679    8975 warnings.go:70] would violate PodSecurity "restricted:latest": privileged (container "sysctl" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "sysctl" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "sysctl" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "sysctl" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "sysctl" must not set runAsUser=0), seccompProfile (pod or container "sysctl" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
W0212 13:13:00.741685    8975 warnings.go:70] would violate PodSecurity "restricted:latest": privileged (container "sysctl" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "sysctl" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "sysctl" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "sysctl" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "sysctl" must not set runAsUser=0), seccompProfile (pod or container "sysctl" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
W0212 13:13:00.742088    8975 warnings.go:70] would violate PodSecurity "restricted:latest": privileged (container "sysctl" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "sysctl" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "sysctl" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "sysctl" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "sysctl" must not set runAsUser=0), seccompProfile (pod or container "sysctl" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
W0212 13:13:00.746932    8975 warnings.go:70] would violate PodSecurity "restricted:latest": privileged (container "sysctl" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "sysctl" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "sysctl" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "sysctl" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "sysctl" must not set runAsUser=0), seccompProfile (pod or container "sysctl" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

These are, however, caused by the OpenSearch dependency, so I'll handle them in a separate PR since it's a bit more involved.

Apart from that, the changes are tested and seems to work.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
