### PR TITLE
Change type of `invenio.extra_env_from_secret`

### DIFF
--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -36,7 +36,12 @@ invenio:
         consumer_key: ""
         consumer_secret: ""
   extra_config: {}
-  extra_env_from_secret: {}
+  extra_env_from_secret: []
+    # - name: NAME_OF_MY_ENV_VAR
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: name-of-my-secret
+    #       key: KEY_IN_MY_SECRET
 
 haproxy:
   enabled: true


### PR DESCRIPTION
### Description

This change fixes a typo for the default value (and importantly: type) of the `invenio.extra_env_from_secret` value.

Before this change, I got the following warning when setting `invenio.extra_env_from_secret`:

```text
coalesce.go:286: warning: cannot overwrite table with non table for invenio.invenio.extra_env_from_secret (map[])
```

This was because the default value of `invenio.extra_env_from_secret` was `{}` (the empty object) while it is clearly used as a list:

https://github.com/inveniosoftware/helm-invenio/blob/eb6544fdeb7e762972db1dae26f848c2f2e4c029/charts/invenio/templates/web-deployment.yaml#L83-L89

https://github.com/inveniosoftware/helm-invenio/blob/eb6544fdeb7e762972db1dae26f848c2f2e4c029/charts/invenio/templates/worker-deployment.yaml#L87-L93

So when setting `invenio.extra_env_from_secret` to a list instead of an object, Helm gets nervous. This change fixes that.

I've also added an example comment to show what the structure of each list item should be.

In the long term, I believe a more overarching change as discussed in #117 is better. My change here is just a quick bug fix.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
