### PR TITLE
persistence: avoid setting empty storageClassName

### DIFF
--- a/charts/invenio/templates/persistentvolumeclaim.yaml
+++ b/charts/invenio/templates/persistentvolumeclaim.yaml
@@ -8,7 +8,9 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
+  {{- if .Values.persistence.storage_class }}
   storageClassName: {{ .Values.persistence.storage_class }}
+  {{- end }}
   accessModes:
   - {{ .Values.persistence.access_mode }}
   resources:


### PR DESCRIPTION
### Description

Without the additional logic introduced in this change, the `storageClassName` field would by default be set to empty string.

For systems with a default storage class configured, setting `storageClassName` to the empty string would be OK during installation since the storage class controller will set the `storageClassName` afterwards.

This, however, does not work for upgrades because then the `storageClassName` of the live object is already set to something and then we try to change that immutable field to the empty string.

This change ensures that the `storageClassName` is only set if we specify `persistence.storage_class`.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
