### PR TITLE
Lindhe/subpath

### DIFF
--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -117,8 +117,10 @@ spec:
           {{- if .Values.persistence.enabled }}
           - mountPath: /opt/invenio/var/instance/data
             name: {{ .Values.persistence.name }}
+            subPath: data
           - mountPath: /opt/invenio/var/instance/profiler
             name: {{ .Values.persistence.name }}
+            subPath: profiler
           {{- end }}
           {{- if .Values.kerberos.enabled }}
           - name: kerberos-credentials-cache

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -116,10 +116,10 @@ spec:
             mountPath: /opt/nginx-invenio-assets
           {{- if .Values.persistence.enabled }}
           - mountPath: /opt/invenio/var/instance/data
-            name: {{ .Values.persistence.name }}
+            name: shared-volume
             subPath: data
           - mountPath: /opt/invenio/var/instance/profiler
-            name: {{ .Values.persistence.name }}
+            name: shared-volume
             subPath: profiler
           {{- end }}
           {{- if .Values.kerberos.enabled }}

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -103,6 +103,7 @@ spec:
             {{- if .Values.persistence.enabled }}
             - mountPath: /opt/invenio/var/instance/data
               name: shared-volume
+              subPath: data
             {{- end }}
             {{- if .Values.kerberos.enabled }}
             - name: kerberos-credentials-cache


### PR DESCRIPTION
### Description

This PR does three things:

1. Reverts an earlier commit that removed `subPath` from the `volumeMounts`.
2. Adds `subPath` to the `worker` pod, where it was missing.
3. Fixes a typo for the volume name.

The reverted commit tried to fix an issue where we got duplicate directory names (`data/data/`), but the issue was not that `web` used `subPath` but actually that `worker` did not.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
4. You agree that you have the right to license your contribution under the current repository’s license.
