### PR TITLE
Support for custom AMQP protocol and external INVENIO_SEARCH_HOSTS

### DIFF
--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -108,9 +108,7 @@
   This template renders the protocol for RabbitMQ.
 */}}
 {{- define "invenio.rabbitmq.protocol" -}}
-  {{- if .Values.rabbitmq.enabled }}
-    {{- include "common.names.fullname" .Subcharts.rabbitmq -}}
-  {{- else }}
+  {{- if .Values.rabbitmq.enabled }}amqp{{- else }}
     {{- required "Missing .Values.rabbitmqExternal.protocol" .Values.rabbitmqExternal.protocol }}
   {{- end }}
 {{- end -}}

--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -103,6 +103,18 @@
   {{- end }}
 {{- end -}}
 
+##########################     RabbitMQ protocol     ##########################
+{{/*
+  This template renders the protocol for RabbitMQ.
+*/}}
+{{- define "invenio.rabbitmq.protocol" -}}
+  {{- if .Values.rabbitmq.enabled }}
+    {{- include "common.names.fullname" .Subcharts.rabbitmq -}}
+  {{- else }}
+    {{- required "Missing .Values.rabbitmqExternal.protocol" .Values.rabbitmqExternal.protocol }}
+  {{- end }}
+{{- end -}}
+
 ##########################     Celery broker URI     ##########################
 {{/*
   This template renders the URI for connecting to RabbitMQ.
@@ -112,7 +124,8 @@
   {{- $password := (include "invenio.rabbitmq.password" .) -}}
   {{- $port := (include "invenio.rabbitmq.amqpPort" .) -}}
   {{- $hostname := (include "invenio.rabbitmq.hostname" .) -}}
-  {{- printf "amqp://%s:%s@%s:%v/" $username $password $hostname $port }}
+  {{- $protocol := (include "invenio.rabbitmq.protocol" .) -}}
+  {{- printf "%s://%s:%s@%s:%v/" $protocol $username $password $hostname $port }}
 {{- end -}}
 
 ###########################     RabbitMQ API URI     ###########################

--- a/charts/invenio/templates/invenio-configmap.yaml
+++ b/charts/invenio/templates/invenio-configmap.yaml
@@ -11,7 +11,10 @@ data:
   INVENIO_CELERY_RESULT_BACKEND: 'redis://{{ include "invenio.redis.hostname" . }}:6379/2'
   INVENIO_RATELIMIT_STORAGE_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/3'
   INVENIO_COMMUNITIES_IDENTITIES_CACHE_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/4'
+  {{- if hasKey .Values.invenio.extra_config "INVENIO_SEARCH_HOSTS" }}
+  {{- else }}
   INVENIO_SEARCH_HOSTS: {{ printf "[{'host': '%s'}]" (include "invenio.opensearch.hostname" .) | quote }}
+  {{- end }}
   INVENIO_SITE_HOSTNAME: '{{ include "invenio.hostname" $ }}'
   INVENIO_SITE_UI_URL: 'https://{{ include "invenio.hostname" $ }}'
   INVENIO_SITE_API_URL: 'https://{{ include "invenio.hostname" $ }}/api'


### PR DESCRIPTION
### Description

This PR solves 2 issues with the Helm chart

#### RabbitMQ protocol can't be customized

The default protocol for RabbitMQ is `amqp` and can't be edited -- this is probably fine when running RabbitMQ locally, but most _hosted_ RMQ instances will only accept connections on `amqps`; this PR adds support for a custom protocol when using `.Values.rabbitmqExternal`

#### Impossible to define custom Search username, password or port

The easiest way to use an external {Open/Elastic}Search instance is to pass `INVENIO_SEARCH_HOSTS` in the environment; however, the way `INVENIO_SEARCH_HOSTS` is set in the Configmap:

```
INVENIO_SEARCH_HOSTS: {{ printf "[{'host': '%s'}]" (include "invenio.opensearch.hostname" .) | quote }}
```

 means that only the `hostname` can be configured, without port, user or password; this is of course unworkable when using an hosted {Elastic/Open}Search that needs proper authentication to be passed to the application.

A possible way around this is to add the `INVENIO_SEARCH_HOSTS` string into `Values.invenio.extra_config`; this will however force Helm to have 2 `INVENIO_SEARCH_HOSTS` in the Configmap -- which won't work either.

In this PR, if `INVENIO_SEARCH_HOSTS` is set in `extra_config`, it is removed from the Configmap so we don't get this defined twice, avoiding clashes and allowing the app to connect to an externally hosted search engine.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] ~~I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).~~
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] ~~I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.~~
- [ ] ~~I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.~~
- [ ] ~~I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.~~


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
3. You agree that you have the right to license your contribution under the current repository’s license.
