### PR TITLE
Enable using preexisting PVC

### DIFF
--- a/charts/invenio/templates/persistentvolumeclaim.yaml
+++ b/charts/invenio/templates/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if (and .Values.persistence.enabled (not .Values.persistence.useExistingClaim)) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -162,6 +162,7 @@ persistence:
   annotations: {}
   size: 10G
   storage_class: ""
+  useExistingClaim: false
 
 redis:
   enabled: true


### PR DESCRIPTION
### Description

This change enables users to provide their own PVC for storing data, rather than forcing them to create a new one. This can be a handy way to decouple the lifecycle management of data from the app, for example to perform backup/restore operations.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
