### PR TITLE
Templated variables inside invenio-config configMap

### DIFF
--- a/charts/invenio/templates/NOTES.txt
+++ b/charts/invenio/templates/NOTES.txt
@@ -1,1 +1,11 @@
 Invenio is ready to rock 🚀
+
+Your release is named {{ .Release.Name }}.
+
+{{- if .Values.invenio.extra_config}}
+
+DEPRECATION WARNING: 
+    `invenio.extra_config` has been renamed to `invenio.extraConfig` and will be
+    removed in a future release.
+
+{{- end }}

--- a/charts/invenio/templates/invenio-configmap.yaml
+++ b/charts/invenio/templates/invenio-configmap.yaml
@@ -20,5 +20,5 @@ data:
   INVENIO_DATACITE_ENABLED: "False"
   INVENIO_LOGGING_CONSOLE_LEVEL: "WARNING"
   {{- range $key, $value := .Values.invenio.extra_config }}
-  {{ $key }}: {{ $value | toYaml | indent 4 | trim }}
+  {{ $key }}: {{ tpl $value $ | toYaml | indent 5 | trim }}
   {{- end }}

--- a/charts/invenio/templates/invenio-configmap.yaml
+++ b/charts/invenio/templates/invenio-configmap.yaml
@@ -20,5 +20,8 @@ data:
   INVENIO_DATACITE_ENABLED: "False"
   INVENIO_LOGGING_CONSOLE_LEVEL: "WARNING"
   {{- range $key, $value := .Values.invenio.extra_config }}
-  {{ $key }}: {{ tpl $value $ | toYaml | indent 5 | trim }}
+  {{ $key }}: {{ $value | toYaml | indent 4 | trim }}
+  {{- end }}
+  {{- range $key, $value := .Values.invenio.extraConfig }}
+  {{ $key }}: {{ tpl $value $ | toYaml | indent 4 | trim }}
   {{- end }}

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -37,6 +37,8 @@ invenio:
       - name: ""
         consumer_key: ""
         consumer_secret: ""
+  ## @param invenio.extra_config Extra environment variables (templated) to be added to all the pods.
+  ##
   extra_config: {}
   extra_env_from_secret: []
     # - name: NAME_OF_MY_ENV_VAR

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -37,9 +37,11 @@ invenio:
       - name: ""
         consumer_key: ""
         consumer_secret: ""
-  ## @param invenio.extra_config Extra environment variables (templated) to be added to all the pods.
-  ##
+  ## @param invenio.extra_config DEPRECATED: invenio.extraConfig instead
   extra_config: {}
+  ## @param invenio.extraConfig Extra environment variables (templated) to be added to all the pods.
+  ##
+  extraConfig: {}
   extra_env_from_secret: []
     # - name: NAME_OF_MY_ENV_VAR
     #   valueFrom:


### PR DESCRIPTION
The first commit is the one that contains the change. 

The second one is a "test" to see what you think about renaming all the non-camelcase variables we have and deprecating them.