### PR TITLE
Nginx updates

### DIFF
--- a/charts/invenio/templates/nginx-configmap.yaml
+++ b/charts/invenio/templates/nginx-configmap.yaml
@@ -143,6 +143,7 @@ data:
 
           uwsgi_buffering off;
           uwsgi_request_buffering off;
+          chunked_transfer_encoding off;
 
           uwsgi_param Host $host;
           uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -167,6 +168,7 @@ data:
 
           uwsgi_buffering off;
           uwsgi_request_buffering off;
+          chunked_transfer_encoding off;
 
           uwsgi_param Host $host;
           uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -192,6 +194,7 @@ data:
 
           uwsgi_buffering off;
           uwsgi_request_buffering off;
+          chunked_transfer_encoding off;
 
           uwsgi_param Host $host;
           uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
* nginx: add "application/javascript" MIME type for mjs files
* nginx: disable chunked transfer encoding for proxied apps

Kudos to @max-moser for doing all the work. I'm just porting it here 😉 