### PR TITLE
invenio: merge base config and extraConfig

### DIFF
--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -299,3 +299,36 @@ Add sentry environmental variables
       key: {{ .Values.invenio.sentry.secretKeys.dsnKey }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Invenio basic configuration variables
+*/}}
+{{- define "invenio.configBase" -}}
+INVENIO_ACCOUNTS_SESSION_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/1'
+INVENIO_APP_ALLOWED_HOSTS: '["{{ include "invenio.hostname" $ }}"]'
+INVENIO_CACHE_REDIS_HOST: '{{ include "invenio.redis.hostname" . }}'
+INVENIO_CACHE_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/0'
+INVENIO_CELERY_RESULT_BACKEND: 'redis://{{ include "invenio.redis.hostname" . }}:6379/2'
+INVENIO_IIIF_CACHE_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/0'
+INVENIO_RATELIMIT_STORAGE_URI: 'redis://{{ include "invenio.redis.hostname" . }}:6379/3'
+INVENIO_COMMUNITIES_IDENTITIES_CACHE_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/4'
+INVENIO_SEARCH_HOSTS: {{ printf "[{'host': '%s'}]" (include "invenio.opensearch.hostname" .) | quote }}
+INVENIO_SITE_HOSTNAME: '{{ include "invenio.hostname" $ }}'
+INVENIO_SITE_UI_URL: 'https://{{ include "invenio.hostname" $ }}'
+INVENIO_SITE_API_URL: 'https://{{ include "invenio.hostname" $ }}/api'
+INVENIO_DATACITE_ENABLED: "False"
+INVENIO_LOGGING_CONSOLE_LEVEL: "WARNING"
+{{- end -}}
+
+{{/*
+Merge invenio.extraConfig and configBase using mergeOverwrite and rendering templates.
+invenio.ExtraConfig will overwrite the values from configBase in case of duplicates.
+*/}}
+{{- define "invenio.mergeConfig" -}}
+{{- $dst := dict -}}
+{{- $values := list (include "invenio.configBase" .)  (.Values.invenio.extraConfig | toYaml) -}}
+{{- range $values -}}
+{{- $dst = tpl  . $ | fromYaml | mergeOverwrite $dst -}}
+{{- end -}}
+{{- $dst | toYaml -}}
+{{- end -}}

--- a/charts/invenio/templates/invenio-configmap.yaml
+++ b/charts/invenio/templates/invenio-configmap.yaml
@@ -6,25 +6,4 @@ metadata:
   labels:
     {{- include "invenio.labels" . | nindent 4 }}
 data:
-  INVENIO_ACCOUNTS_SESSION_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/1'
-  INVENIO_APP_ALLOWED_HOSTS: '["{{ include "invenio.hostname" $ }}"]'
-  INVENIO_CACHE_REDIS_HOST: '{{ include "invenio.redis.hostname" . }}'
-  INVENIO_CACHE_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/0'
-  INVENIO_CELERY_RESULT_BACKEND: 'redis://{{ include "invenio.redis.hostname" . }}:6379/2'
-  INVENIO_IIIF_CACHE_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/0'
-  INVENIO_RATELIMIT_STORAGE_URI: 'redis://{{ include "invenio.redis.hostname" . }}:6379/3'
-  INVENIO_COMMUNITIES_IDENTITIES_CACHE_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/4'
-  {{- if not (hasKey .Values.invenio.extra_config "INVENIO_SEARCH_HOSTS") }}
-  INVENIO_SEARCH_HOSTS: {{ printf "[{'host': '%s'}]" (include "invenio.opensearch.hostname" .) | quote }}
-  {{- end }}
-  INVENIO_SITE_HOSTNAME: '{{ include "invenio.hostname" $ }}'
-  INVENIO_SITE_UI_URL: 'https://{{ include "invenio.hostname" $ }}'
-  INVENIO_SITE_API_URL: 'https://{{ include "invenio.hostname" $ }}/api'
-  INVENIO_DATACITE_ENABLED: "False"
-  INVENIO_LOGGING_CONSOLE_LEVEL: "WARNING"
-  {{- range $key, $value := .Values.invenio.extra_config }}
-  {{ $key }}: {{ $value | toYaml | indent 4 | trim }}
-  {{- end }}
-  {{- range $key, $value := .Values.invenio.extraConfig }}
-  {{ $key }}: {{ tpl $value $ | toYaml | indent 4 | trim }}
-  {{- end }}
+  {{- include "invenio.mergeConfig" . | nindent 2 -}}

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: web
   labels:
     {{- include "invenio.labels" . | nindent 4 }}
+  annotations:
+    checksum/invenio-configmap: {{ include (print $.Template.BasePath "/invenio-configmap.yaml") . | sha256sum }}
 spec:
   replicas: {{ .Values.web.replicas }}
   selector:

--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: worker-beat
   labels:
     {{- include "invenio.labels" . | nindent 4 }}
+  annotations:
+    checksum/invenio-configmap: {{ include (print $.Template.BasePath "/invenio-configmap.yaml") . | sha256sum }}
 spec:
   replicas: 1
   selector:

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: worker
   labels:
     {{- include "invenio.labels" . | nindent 4 }}
+  annotations:
+    checksum/invenio-configmap: {{ include (print $.Template.BasePath "/invenio-configmap.yaml") . | sha256sum }}
 spec:
   replicas: {{ .Values.worker.replicas }}
   selector:


### PR DESCRIPTION
* Adds annotation to force pod recreation in case of changes (addresses #142).

---
 Without any extra variable or overwrite
```
invenio:
  hostname: foo
  secret_key: foo
  security_login_salt: foo
  csrf_secret_salt: foo
postgresql:
  auth:
    password: foo
rabbitmq:
  enabled: true
  auth:
    password: foo
```

```
$ helm template -f values.yaml  ./charts/invenio  -s templates/invenio-configmap.yaml
---
# Source: invenio/templates/invenio-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: invenio-config
  labels:
    helm.sh/chart: invenio-0.3.0
    app.kubernetes.io/name: invenio
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v12.0.0-beta.1.3"
    app.kubernetes.io/managed-by: Helm
data:
  INVENIO_ACCOUNTS_SESSION_REDIS_URL: redis://release-name-redis-master:6379/1
  INVENIO_APP_ALLOWED_HOSTS: '["foo"]'
  INVENIO_CACHE_REDIS_HOST: release-name-redis-master
  INVENIO_CACHE_REDIS_URL: redis://release-name-redis-master:6379/0
  INVENIO_CELERY_RESULT_BACKEND: redis://release-name-redis-master:6379/2
  INVENIO_COMMUNITIES_IDENTITIES_CACHE_REDIS_URL: redis://release-name-redis-master:6379/4
  INVENIO_DATACITE_ENABLED: "False"
  INVENIO_IIIF_CACHE_REDIS_URL: redis://release-name-redis-master:6379/0
  INVENIO_LOGGING_CONSOLE_LEVEL: WARNING
  INVENIO_RATELIMIT_STORAGE_URI: redis://release-name-redis-master:6379/3
  INVENIO_SEARCH_HOSTS: '[{''host'': ''release-name-opensearch''}]'
  INVENIO_SITE_API_URL: https://foo/api
  INVENIO_SITE_HOSTNAME: foo
  INVENIO_SITE_UI_URL: https://foo
```
 
With `extraConfig` and overwrite
```
invenio:
  hostname: foo
  secret_key: foo
  security_login_salt: foo
  csrf_secret_salt: foo
  extraConfig:
    INVENIO_APP_ALLOWED_HOSTS: '["definitely not foo "]'
postgresql:
  auth:
    password: foo
rabbitmq:
  enabled: true
  auth:
    password: foo
```
```
helm template -f values.yaml  ./charts/invenio  -s templates/invenio-configmap.yaml
---
# Source: invenio/templates/invenio-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: invenio-config
  labels:
    helm.sh/chart: invenio-0.3.0
    app.kubernetes.io/name: invenio
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v12.0.0-beta.1.3"
    app.kubernetes.io/managed-by: Helm
data:
  INVENIO_ACCOUNTS_SESSION_REDIS_URL: redis://release-name-redis-master:6379/1
  INVENIO_APP_ALLOWED_HOSTS: '["definitely not foo "]'
  INVENIO_CACHE_REDIS_HOST: release-name-redis-master
  INVENIO_CACHE_REDIS_URL: redis://release-name-redis-master:6379/0
  INVENIO_CELERY_RESULT_BACKEND: redis://release-name-redis-master:6379/2
  INVENIO_COMMUNITIES_IDENTITIES_CACHE_REDIS_URL: redis://release-name-redis-master:6379/4
  INVENIO_DATACITE_ENABLED: "False"
  INVENIO_IIIF_CACHE_REDIS_URL: redis://release-name-redis-master:6379/0
  INVENIO_LOGGING_CONSOLE_LEVEL: WARNING
  INVENIO_RATELIMIT_STORAGE_URI: redis://release-name-redis-master:6379/3
  INVENIO_SEARCH_HOSTS: '[{''host'': ''release-name-opensearch''}]'
  INVENIO_SITE_API_URL: https://foo/api
  INVENIO_SITE_HOSTNAME: foo
  INVENIO_SITE_UI_URL: https://foo
```
