### PR TITLE
fix: change secretKeyRef to secretRef in envFrom

### DIFF
--- a/charts/invenio/templates/install-init-job.yaml
+++ b/charts/invenio/templates/install-init-job.yaml
@@ -33,7 +33,7 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "invenio.fullname" . }}-config
-         - secretKeyRef:
+         - secretRef:
             name: {{ include "invenio.secretName" . }}
         env:
         - name: TZ

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "invenio.fullname" . }}-config
-        - secretKeyRef:
+        - secretRef:
             name: {{ include "invenio.secretName" . }}
         env:
         - name: TZ

--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -44,7 +44,7 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "invenio.fullname" . }}-config
-        - secretKeyRef:
+        - secretRef:
             name: {{ include "invenio.secretName" . }}
         env:
         - name: TZ

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "invenio.fullname" . }}-config
-            - secretKeyRef:
+            - secretRef:
                 name: {{ include "invenio.secretName" . }}
           env:
           - name: TZ


### PR DESCRIPTION
### Description

The `envFrom` field takes `secretRef`, not
`secretKeyRef` like `env.valueFrom` does.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
