### PR TITLE
fix: Set Recreate strategy in beat for safety

### DIFF
--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "invenio.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker-beat
 spec:
-  replicas: 1
+  replicas: 1 # For data safety, beat must never have more than 1 replica!
   selector:
     matchLabels:
       app.kubernetes.io/component: worker-beat
@@ -123,3 +123,5 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.worker.imagePullSecret }}
       {{- end }}
+  strategy:
+    type: Recreate # For data safety, beat must never have more than 1 replica!


### PR DESCRIPTION
### Description

Before this change, worker-beat had the default strategy "RollingUpdate", allowing for two replicas to temporarily coexist during updates.
This, however, was not safe behavior for worker-beat, as documented here: https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html

> You have to ensure only a single scheduler is running for a schedule
> at a time, otherwise you’d end up with duplicate tasks. Using a
> centralized approach means the schedule doesn’t have to be
> synchronized, and the service can operate without using locks.

This change fixes this by setting the "Recreate" strategy, ensuring that more than 1 replica never exists.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
