### PR TITLE
invenio: refactor datacite block

### DIFF
--- a/charts/invenio/templates/NOTES.txt
+++ b/charts/invenio/templates/NOTES.txt
@@ -44,3 +44,20 @@ DEPRECATION WARNING:
     `invenio.existingSecret` and it will be removed in a future release.
 
 {{- end }}
+
+{{- if .Values.invenio.datacite.existing_secret }}
+
+DEPRECATION WARNING: 
+    `invenio.datacite.existing_secret` has been renamed to `invenio.datacite.existingSecret`
+    and its type has changed from boolean to string.
+    This key will be removed in a future release.
+
+{{- end }}
+
+{{- if .Values.invenio.datacite.secret_name }}
+
+DEPRECATION WARNING: 
+    `invenio.datacite.secret_name` has been renamed in favor of
+    `invenio.datacite.existingSecret` will be removed in a future release.
+
+{{- end }}

--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -334,7 +334,7 @@ INVENIO_SEARCH_HOSTS: {{ printf "[{'host': '%s'}]" (include "invenio.opensearch.
 INVENIO_SITE_HOSTNAME: '{{ include "invenio.hostname" $ }}'
 INVENIO_SITE_UI_URL: 'https://{{ include "invenio.hostname" $ }}'
 INVENIO_SITE_API_URL: 'https://{{ include "invenio.hostname" $ }}/api'
-INVENIO_DATACITE_ENABLED: {{ternary "True" "False" .Values.invenio.datacite.enabled | quote }}
+INVENIO_DATACITE_ENABLED: {{ ternary "True" "False" .Values.invenio.datacite.enabled | quote }}
 INVENIO_LOGGING_CONSOLE_LEVEL: "WARNING"
 {{- end -}}
 

--- a/charts/invenio/templates/datacite-secret.yaml
+++ b/charts/invenio/templates/datacite-secret.yaml
@@ -1,13 +1,12 @@
-{{- if and (.Values.invenio.datacite.enabled) (not .Values.invenio.datacite.existing_secret)}}
+{{- if and (.Values.invenio.datacite.enabled) (not (or .Values.invenio.datacite.existingSecret .Values.invenio.datacite.existing_secret))}}
 ---
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: datacite-secrets
+  name: {{ include "invenio.dataciteSecretName" . }}
   labels:
     {{- include "invenio.labels" . | nindent 4 }}
-    app: datacite-secrets
   annotations:
     helm.sh/resource-policy: keep
 data:

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -46,18 +46,7 @@ spec:
         {{-  toYaml . | nindent 8 }}
         {{- end }}
         {{- include "invenio.config.sentry" . | nindent 8 }}
-        {{- if .Values.invenio.datacite.enabled }}
-        - name: INVENIO_DATACITE_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.invenio.datacite.secret_name }}
-              key: DATACITE_USERNAME
-        - name: INVENIO_DATACITE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.invenio.datacite.secret_name }}
-              key: DATACITE_PASSWORD
-        {{- end }}
+        {{- include "invenio.config.datacite" . | nindent 8 }}
         {{- if .Values.invenio.remote_apps.enabled }}
         {{- range .Values.invenio.remote_apps.credentials }}
         - name: {{ default (printf "INVENIO_%s_APP_CREDENTIALS" .name) }}

--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -58,18 +58,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- include "invenio.config.sentry" . | nindent 8 }}
-        {{- if .Values.invenio.datacite.enabled }}
-        - name: INVENIO_DATACITE_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.invenio.datacite.secret_name }}
-              key: DATACITE_USERNAME
-        - name: INVENIO_DATACITE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.invenio.datacite.secret_name }}
-              key: DATACITE_PASSWORD
-        {{- end }}
+        {{- include "invenio.config.datacite" . | nindent 8 }}
         {{- range .Values.invenio.extra_env_from_secret }}
         - name: {{ .name }}
           valueFrom:

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -49,18 +49,7 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- include "invenio.config.sentry" . | nindent 10 }}
-          {{- if .Values.invenio.datacite.enabled }}
-          - name: INVENIO_DATACITE_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.invenio.datacite.secret_name }}
-                key: DATACITE_USERNAME
-          - name: INVENIO_DATACITE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.invenio.datacite.secret_name }}
-                key: DATACITE_PASSWORD
-          {{- end }}
+          {{- include "invenio.config.datacite" . | nindent 10 }}
           {{- if .Values.invenio.remote_apps.enabled }}
           {{- range .Values.invenio.remote_apps.credentials }}
           - name: {{ default (printf "INVENIO_%s_APP_CREDENTIALS" .name) }}

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -60,8 +60,29 @@ invenio:
     secretKeys:
       dsnKey: "SENTRY_DSN"
   datacite:
+    ## @param invenio.datacite.enabled Enable DataCite provider
+    ##
     enabled: false
+    ## @param invenio.datacite.username Datacite username
+    ##
+    username: ""
+    ## @param invenio.datacite.password Datacite password
+    ##
+    password: ""
+    ## @param invenio.datacite.existingSecret Existing secret name for datacite username and password
+    ##
+    existingSecret: ""
+    ## @param invenio.datacite.secretKeys.usernameKey Name of key in existing secret to use for username. Only used when `invenio.datacite.existingSecret` is set.
+    ## @param invenio.datacite.secretKeys.passwordKey Name of key in existing secret to use for password. Only used when `invenio.datacite.existingSecret` is set.
+    ##
+    secretKeys:
+      usernameKey: "DATACITE_USERNAME"
+      passwordKey: "DATACITE_PASSWORD"
+    ## @param invenio.datacite.existing_secret DEPRECATED: use invenio.datacite.existingSecret instead
+    ##
     existing_secret: false
+    ## @param invenio.datacite.secret_name DEPRECATED: use invenio.datacite.existingSecret instead
+    ##
     secret_name: "datacite-secrets"
   podSecurityContext:
     enabled: true


### PR DESCRIPTION
* Deprecates non-camelcase datacite variables.

* Addresses secret handling as described in #117.