### PR TITLE
chore: Normalize how `resources` are set for each container

### DIFF
--- a/charts/invenio/templates/NOTES.txt
+++ b/charts/invenio/templates/NOTES.txt
@@ -61,3 +61,50 @@ DEPRECATION WARNING:
     `invenio.datacite.existingSecret` will be removed in a future release.
 
 {{- end }}
+
+{{/*
+BEGIN: Warning on unset resources.
+*/}}
+
+{{- $fieldsToCheckForResources := list
+"flower"
+"haproxy"
+"kerberos.initContainers"
+"kerberos"
+"nginx"
+"web.initContainers"
+"web"
+"worker"
+"workerBeat"
+-}}
+
+{{- $fieldsWithResourcesUnset := list -}}
+
+{{- range $fieldsToCheckForResources -}}
+    {{- $path := splitList "." . -}}
+    {{- $values := $.Values -}}
+    {{- range $path -}}
+        {{- $values = index $values . -}}
+    {{- end -}}
+    {{- if not $values.resources -}}
+        {{ $fieldsWithResourcesUnset = append $fieldsWithResourcesUnset . -}}
+    {{- end -}}
+{{- end -}}
+
+{{- with $fieldsWithResourcesUnset }}
+
+💡 MISSING RESOURCES: It seems like `resources` is unset for one or more containers. We strongly recommend that you set them. The `resources` field is unset in the following places:
+
+{{- "\n" -}}
+{{ range . }}
+.Values.{{ . }}
+{{- end }}
+
+You can read more about resource management in Kubernetes here:
+https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+{{- end }}
+
+{{/*
+END: Warning on unset resources.
+*/}}

--- a/charts/invenio/templates/flower/deployment.yaml
+++ b/charts/invenio/templates/flower/deployment.yaml
@@ -54,9 +54,7 @@ spec:
             {{- . | toYaml | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- if .Values.flower.resources }}
           resources: {{- toYaml .Values.flower.resources | nindent 12 }}
-          {{- end }}
           volumeMounts:
             - name: celery-config-volume
               mountPath: /var/celery

--- a/charts/invenio/templates/haproxy/deployment.yaml
+++ b/charts/invenio/templates/haproxy/deployment.yaml
@@ -38,9 +38,7 @@ spec:
             - name: haproxy-config
               mountPath: /usr/local/etc/haproxy/backup-website.http
               subPath: backup-website.http
-          {{- if .Values.haproxy.resources }}
           resources: {{- toYaml .Values.haproxy.resources | nindent 12 }}
-          {{- end }}
       volumes:
         - name: haproxy-config
           configMap:

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -218,7 +218,7 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ .Values.kerberos.secret_name }}
-          resources: {{- toYaml .Values.kerberos.resources | nindent 12 }}
+          resources: {{- toYaml .Values.kerberos.initContainers.resources | nindent 12 }}
           volumeMounts:
             - name: kerberos-credentials-cache
               mountPath: /tmp

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -147,9 +147,7 @@ spec:
             port: 8080
           initialDelaySeconds: 15
           timeoutSeconds: 1
-        {{- if .Values.nginx.resources }}
         resources: {{- toYaml .Values.nginx.resources | nindent 10 }}
-        {{- end }}
         securityContext:
           {{- with .Values.nginx.securityContext }}
           {{- toYaml . | nindent 10 }}

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -33,9 +33,7 @@ spec:
             "-c",
             "uwsgi --ini /opt/invenio/src/uwsgi/uwsgi.ini",
         ]
-        {{- if .Values.web.resources }}
         resources: {{- toYaml .Values.web.resources | nindent 10 }}
-        {{- end }}
         envFrom:
         - configMapRef:
             name: {{ include "invenio.fullname" . }}-config

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -202,10 +202,7 @@ spec:
               "-c",
               "cp -R {{ .Values.web.assets.location }}/. /opt/nginx-invenio-assets/",
           ]
-         {{- if .Values.web.initContainers.resources }}
-          resources:
-            {{- toYaml .Values.web.initContainers.resources | nindent 12 }}
-          {{- end }}
+          resources: {{- toYaml .Values.web.initContainers.resources | nindent 12 }}
           securityContext:
             {{- with .Values.web.initContainers.securityContext }}
             {{- toYaml . | nindent 12 }}

--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -84,17 +84,7 @@ spec:
               - "celery -A {{ .Values.worker.app }} inspect ping"
           initialDelaySeconds: 20
           timeoutSeconds: 30
-        {{- if .Values.worker.resources }}
         resources: {{- toYaml .Values.workerBeat.resources | nindent 10 }}
-        {{- else }}
-        resources:
-          requests:
-            cpu: 500m
-            memory: 200Mi
-          limits:
-            cpu: '2'
-            memory: 500Mi
-        {{- end }}
       securityContext:
         {{- with .Values.workerBeat.podSecurityContext }}
         {{- toYaml . | nindent 8 }}

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -125,7 +125,7 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ .Values.kerberos.secret_name }}
-          resources: {{- toYaml .Values.kerberos.resources | nindent 12 }}
+          resources: {{- toYaml .Values.kerberos.initContainers.resources | nindent 12 }}
           volumeMounts:
             - name: kerberos-credentials-cache
               mountPath: /tmp

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -32,9 +32,7 @@ spec:
               "-c",
               "celery -A {{ .Values.worker.app }} worker -c {{ .Values.worker.concurrency }} -l {{ .Values.worker.log_level }}"
           ]
-          {{- if .Values.worker.resources }}
           resources: {{- toYaml .Values.worker.resources | nindent 12 }}
-          {{- end }}
           securityContext:
             {{- with .Values.worker.securityContext }}
             {{- toYaml . | nindent 12 }}

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -251,13 +251,20 @@ web:
     #   cpu: 1000m
     #   memory: 1Gi
   initContainers:
-    resources:
-      requests:
-        cpu: '1'
-        memory: 100Mi
-      limits:
-        cpu: '1'
-        memory: 100Mi
+    ## @param web.initContainers.resources `resources` for the copy-web-assets initContainer
+    ##
+    ## We have decided to unset resources by default, leaving that as a conscious choice for the user.
+    ## One reason for this is that we want it to be possible to install the chart in minimal environments like minikube.
+    ## Another reason for this choice is that it's practically impossible to know which resource requests/limits are right, since that is entirely dependent on the hardware resources available in the target cluster as well as how the application is used (ammount of traffic, number of concurrent users, size of uploaded artifacts, etc.).
+    ## Therefore, we think it's better that users get to set the resources explicitly for each container.
+    ##
+    resources: {}
+      # requests:
+      #   cpu: '1'
+      #   memory: 100Mi
+      # limits:
+      #   cpu: '1'
+      #   memory: 100Mi
     ## @param web.initContainers.securityContext securityContext for the initContainers in the web pod
     ##
     securityContext:

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -491,13 +491,20 @@ flower:
   default_username: "flower"
   default_password: "flower_password"
   host: ""
-  resources:
-    requests:
-      memory: 125Mi
-      cpu: 0.02
-    limits:
-      memory: 250Mi
-      cpu: 0.1
+  ## @param flower.resources `resources` for the flower-management container
+  ##
+  ## We have decided to unset resources by default, leaving that as a conscious choice for the user.
+  ## One reason for this is that we want it to be possible to install the chart in minimal environments like minikube.
+  ## Another reason for this choice is that it's practically impossible to know which resource requests/limits are right, since that is entirely dependent on the hardware resources available in the target cluster as well as how the application is used (ammount of traffic, number of concurrent users, size of uploaded artifacts, etc.).
+  ## Therefore, we think it's better that users get to set the resources explicitly for each container.
+  ##
+  resources: {}
+    # requests:
+    #   memory: 125Mi
+    #   cpu: 0.02
+    # limits:
+    #   memory: 250Mi
+    #   cpu: 0.1
   ## @param flower.extraEnvFrom Extra secretRef or configMapRef for the `envFrom` field in the flower container
   ##
   extraEnvFrom: []

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -342,13 +342,20 @@ workerBeat:
   ## @param workerBeat.extraEnvVars Extra environment variables (templated) to be added to the pods.
   ##
   extraEnvVars: []
-  resources:
-    requests:
-      cpu: 500m
-      memory: 200Mi
-    limits:
-      cpu: "2"
-      memory: 500Mi
+  ## @param workerBeat.resources `resources` for the worker-beat container
+  ##
+  ## We have decided to unset resources by default, leaving that as a conscious choice for the user.
+  ## One reason for this is that we want it to be possible to install the chart in minimal environments like minikube.
+  ## Another reason for this choice is that it's practically impossible to know which resource requests/limits are right, since that is entirely dependent on the hardware resources available in the target cluster as well as how the application is used (ammount of traffic, number of concurrent users, size of uploaded artifacts, etc.).
+  ## Therefore, we think it's better that users get to set the resources explicitly for each container.
+  ##
+  resources: {}
+    # limits:
+    #   cpu: "2"
+    #   memory: 500Mi
+    # requests:
+    #   cpu: 500m
+    #   memory: 200Mi
   ## @param workerBeat.securityContext securityContext for the worker-beat container
   ##
   securityContext:

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -596,8 +596,7 @@ kerberos:
   image: ""
   args: []
   initArgs: []
-  ## @param kerberos.resources `resources` for the kerberos-credentials
-  ## container and init-kerberos-credentials initContainer
+  ## @param kerberos.resources `resources` for the kerberos-credentials container
   ##
   ## We have decided to unset resources by default, leaving that as a conscious choice for the user.
   ## One reason for this is that we want it to be possible to install the chart in minimal environments like minikube.
@@ -618,3 +617,18 @@ kerberos:
     capabilities:
       drop:
         - ALL
+  initContainers:
+    ## @param kerberos.initContainers.resources `resources` for the init-kerberos-credentials initContainers
+    ##
+    ## We have decided to unset resources by default, leaving that as a conscious choice for the user.
+    ## One reason for this is that we want it to be possible to install the chart in minimal environments like minikube.
+    ## Another reason for this choice is that it's practically impossible to know which resource requests/limits are right, since that is entirely dependent on the hardware resources available in the target cluster as well as how the application is used (ammount of traffic, number of concurrent users, size of uploaded artifacts, etc.).
+    ## Therefore, we think it's better that users get to set the resources explicitly for each container.
+    ##
+    resources: {}
+      # limits:
+      #   cpu: 100m
+      #   memory: 20Mi
+      # requests:
+      #   cpu: 10m
+      #   memory: 2Mi

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -319,13 +319,20 @@ worker:
   ## @param worker.extraEnvVars Extra environment variables (templated) to be added to the pods.
   ##
   extraEnvVars: []
-  resources:
-    requests:
-      cpu: 500m
-      memory: 500Mi
-    limits:
-      cpu: 1000m
-      memory: 1Gi
+  ## @param worker.resources `resources` for the worker container
+  ##
+  ## We have decided to unset resources by default, leaving that as a conscious choice for the user.
+  ## One reason for this is that we want it to be possible to install the chart in minimal environments like minikube.
+  ## Another reason for this choice is that it's practically impossible to know which resource requests/limits are right, since that is entirely dependent on the hardware resources available in the target cluster as well as how the application is used (ammount of traffic, number of concurrent users, size of uploaded artifacts, etc.).
+  ## Therefore, we think it's better that users get to set the resources explicitly for each container.
+  ##
+  resources: {}
+    # requests:
+    #   cpu: 500m
+    #   memory: 500Mi
+    # limits:
+    #   cpu: 1000m
+    #   memory: 1Gi
   volumes:
     enabled: false
   ## @param worker.podSecurityContext securityContext for the worker Pod

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -437,22 +437,8 @@ redis:
     enabled: false  # Dangerous! This lets Invenio connect to Redis unauthenticated!
   master:
     disableCommands: []  # Dangerous! This lets us run the `FLUSHALL` and `FLUSHDB` commands! Unfortunately, they are required by the wipe_recreate.sh script when installing Invenio.
-    resources:
-      limits:
-        cpu: "1"
-        memory: 2Gi
-      requests:
-        cpu: 500m
-        memory: 500Mi
   replica:
     disableCommands: []  # Dangerous! This lets us run the `FLUSHALL` and `FLUSHDB` commands! Unfortunately, they are required by the wipe_recreate.sh script when installing Invenio.
-    resources:
-      limits:
-        cpu: "1"
-        memory: 2Gi
-      requests:
-        cpu: 500m
-        memory: 500Mi
 
 ## RabbitMQ chart configuration
 ## ref: https://github.com/bitnami/charts/blob/main/bitnami/rabbitmq/values.yaml
@@ -460,13 +446,6 @@ rabbitmq:
   enabled: true
   auth:
     password: ""
-  resources:
-    limits:
-      cpu: "1"
-      memory: 2Gi
-    requests:
-      cpu: "1"
-      memory: 2Gi
 
 ## External RabbitMQ configuration
 ## All of these values are only used when rabbitmq.enabled is set to false

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -590,20 +590,27 @@ logstash:
       drop:
         - ALL
 
-
 kerberos:
   enabled: false
   secret_name: ""
   image: ""
   args: []
   initArgs: []
-  resources:
-    limits:
-      cpu: 100m
-      memory: 20Mi
-    requests:
-      cpu: 10m
-      memory: 2Mi
+  ## @param kerberos.resources `resources` for the kerberos-credentials
+  ## container and init-kerberos-credentials initContainer
+  ##
+  ## We have decided to unset resources by default, leaving that as a conscious choice for the user.
+  ## One reason for this is that we want it to be possible to install the chart in minimal environments like minikube.
+  ## Another reason for this choice is that it's practically impossible to know which resource requests/limits are right, since that is entirely dependent on the hardware resources available in the target cluster as well as how the application is used (ammount of traffic, number of concurrent users, size of uploaded artifacts, etc.).
+  ## Therefore, we think it's better that users get to set the resources explicitly for each container.
+  ##
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 20Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 2Mi
   ## @param kerberos.securityContext securityContext for the kerberos container
   ##
   securityContext:

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -236,13 +236,20 @@ web:
     timeoutSeconds: 5
   assets:
     location: /opt/invenio/var/instance/static
-  resources:
-    requests:
-      cpu: 500m
-      memory: 500Mi
-    limits:
-      cpu: 1000m
-      memory: 1Gi
+  ## @param web.resources `resources` for the web container
+  ##
+  ## We have decided to unset resources by default, leaving that as a conscious choice for the user.
+  ## One reason for this is that we want it to be possible to install the chart in minimal environments like minikube.
+  ## Another reason for this choice is that it's practically impossible to know which resource requests/limits are right, since that is entirely dependent on the hardware resources available in the target cluster as well as how the application is used (ammount of traffic, number of concurrent users, size of uploaded artifacts, etc.).
+  ## Therefore, we think it's better that users get to set the resources explicitly for each container.
+  ##
+  resources: {}
+    # requests:
+    #   cpu: 500m
+    #   memory: 500Mi
+    # limits:
+    #   cpu: 1000m
+    #   memory: 1Gi
   initContainers:
     resources:
       requests:

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -145,13 +145,20 @@ haproxy:
   replicas: 2
   maxconn: 100
   maxconn_static: 500
-  resources:
-    requests:
-      cpu: 250m
-      memory: 500Mi
-    limits:
-      cpu: 250m
-      memory: 500Mi
+  ## @param haproxy.resources `resources` for the haproxy container
+  ##
+  ## We have decided to unset resources by default, leaving that as a conscious choice for the user.
+  ## One reason for this is that we want it to be possible to install the chart in minimal environments like minikube.
+  ## Another reason for this choice is that it's practically impossible to know which resource requests/limits are right, since that is entirely dependent on the hardware resources available in the target cluster as well as how the application is used (ammount of traffic, number of concurrent users, size of uploaded artifacts, etc.).
+  ## Therefore, we think it's better that users get to set the resources explicitly for each container.
+  ##
+  resources: {}
+    # requests:
+    #   cpu: 250m
+    #   memory: 500Mi
+    # limits:
+    #   cpu: 250m
+    #   memory: 500Mi
   denied_ips: ""
   denied_uas: ""
   extra_frontend_public_http_request: ""

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -181,13 +181,20 @@ nginx:
     client_max_body_size: 100m
   files:
     client_max_body_size: 50G
-  resources:
-    requests:
-      cpu: 250m
-      memory: 500Mi
-    limits:
-      cpu: 250m
-      memory: 500Mi
+  ## @param nginx.resources `resources` for the nginx container
+  ##
+  ## We have decided to unset resources by default, leaving that as a conscious choice for the user.
+  ## One reason for this is that we want it to be possible to install the chart in minimal environments like minikube.
+  ## Another reason for this choice is that it's practically impossible to know which resource requests/limits are right, since that is entirely dependent on the hardware resources available in the target cluster as well as how the application is used (ammount of traffic, number of concurrent users, size of uploaded artifacts, etc.).
+  ## Therefore, we think it's better that users get to set the resources explicitly for each container.
+  ##
+  resources: {}
+    # requests:
+    #   cpu: 250m
+    #   memory: 500Mi
+    # limits:
+    #   cpu: 250m
+    #   memory: 500Mi
   extra_server_config: ""
   denied_ips: ""
   denied_uas: ""


### PR DESCRIPTION
### Description

This PR normalizes how we set `resources` for each container and initContainer, first by standardizing how we include the values in the templates and secondly by resouces to `{}` by default, aligned with Bitnami's standard.

Here's one example of Bitnami documenting their reasoning for it:

> We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube.

— https://github.com/bitnami/charts/blob/7345c0bb2842b73f299aacd2af37147bd7b714cd/bitnami/nginx/values.yaml#L331-L334

We don't have to follow Bitnami's standard, but I think it's reasonable to do so. Unless we are very confident that a container has some upper/lower bound on its resource utilization, it's probably best to condition the chart user to always set the resources explicitly.

Considering how Kubernetes hide the exact capacity of CPU cores etc., it's pretty much impossible to set resource requests/limits that work the same for everyone. This strategy also reduces the need to make additional changes when updating the chart's default images in the future.

Fixes #109 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
