### PR TITLE
fix: Set default probes to `null` not `{}`

### DIFF
--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -276,7 +276,7 @@ web:
     timeoutSeconds: 5
   ## @param web.livenessProbe templated `livenessProbe` for the web container
   ##
-  livenessProbe: {}
+  livenessProbe: null
   assets:
     location: /opt/invenio/var/instance/static
   ## @param web.resources `resources` for the web container
@@ -427,10 +427,10 @@ worker:
     timeoutSeconds: 30
   ## @param worker.readinessProbe templated `readinessProbe` for the worker container
   ##
-  readinessProbe: {}
+  readinessProbe: null
   ## @param worker.startupProbe templated `startupProbe` for the worker container
   ##
-  startupProbe: {}
+  startupProbe: null
 
 workerBeat:
   ## @param workerBeat.extraEnvVars Extra environment variables to be added to the pods.
@@ -492,10 +492,10 @@ workerBeat:
     timeoutSeconds: 30
   ## @param workerBeat.readinessProbe templated `readinessProbe` for the worker-beat container
   ##
-  readinessProbe: {}
+  readinessProbe: null
   ## @param workerBeat.startupProbe templated `startupProbe` for the worker-beat container
   ##
-  startupProbe: {}
+  startupProbe: null
 
 persistence:
   enabled: true
@@ -583,13 +583,13 @@ flower:
   tolerations: []
   ## @param flower.livenessProbe templated `livenessProbe` for the flower-management container
   ##
-  livenessProbe: {}
+  livenessProbe: null
   ## @param flower.readinessProbe templated `readinessProbe` for the flower-management container
   ##
-  readinessProbe: {}
+  readinessProbe: null
   ## @param flower.startupProbe templated `startupProbe` for the flower-management container
   ##
-  startupProbe: {}
+  startupProbe: null
 
 ## PostgreSQL chart configuration
 ## ref: https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml


### PR DESCRIPTION
### Description

Turns out that `{}` is an invalid default value for probes. Thought I had tested this, but apparently not. 🙄

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
