### PR TITLE
fix: Improve missing resources warning

### DIFF
--- a/charts/invenio/templates/NOTES.txt
+++ b/charts/invenio/templates/NOTES.txt
@@ -69,10 +69,8 @@ BEGIN: Warning on unset resources.
 {{- $fieldsToCheckForResources := list
 "flower"
 "haproxy"
-"kerberos.initContainers"
 "kerberos"
 "nginx"
-"web.initContainers"
 "web"
 "worker"
 "workerBeat"
@@ -86,8 +84,13 @@ BEGIN: Warning on unset resources.
     {{- range $path -}}
         {{- $values = index $values . -}}
     {{- end -}}
-    {{- if not $values.resources -}}
-        {{ $fieldsWithResourcesUnset = append $fieldsWithResourcesUnset . -}}
+    {{- if or (not (hasKey $values "enabled")) $values.enabled -}}
+        {{- if not $values.resources -}}
+            {{ $fieldsWithResourcesUnset = append $fieldsWithResourcesUnset . -}}
+        {{- end -}}
+        {{- if (and $values.initContainers (not $values.initContainers.resources)) -}}
+            {{ $fieldsWithResourcesUnset = append $fieldsWithResourcesUnset (print . ".initContainers") -}}
+        {{- end -}}
     {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### Description

This change improves the logic for when the warning about missing resources should be printed.
Before, it printed even for disabled resources.
Now, it does not print a warning for disabled resources and it dynamically checks for `initContainers` subresources.

Fixes #182

> [!TIP]
> This change is easier to review if you ignore space changes.
> 
> `git show --ignore-space-change`

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
