### PR TITLE
chore: Set datacite secret using new parameter

### DIFF
--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -98,7 +98,7 @@ invenio:
     password: ""
     ## @param invenio.datacite.existingSecret Existing secret name for datacite username and password
     ##
-    existingSecret: ""
+    existingSecret: "datacite-secrets"
     ## @param invenio.datacite.secretKeys.usernameKey Name of key in existing secret to use for username. Only used when `invenio.datacite.existingSecret` is set.
     ## @param invenio.datacite.secretKeys.passwordKey Name of key in existing secret to use for password. Only used when `invenio.datacite.existingSecret` is set.
     ##
@@ -110,7 +110,7 @@ invenio:
     existing_secret: false
     ## @param invenio.datacite.secret_name DEPRECATED: use invenio.datacite.existingSecret instead
     ##
-    secret_name: "datacite-secrets"
+    secret_name: ""
   podSecurityContext:
     enabled: true
   remote_apps:


### PR DESCRIPTION
### Description

This change unsets the deprecated `invenio.datacite.secret_name` value, which has been repaced by `invenio.datacite.existingSecret`, so that the deprecation warning only shows up if a user has explicitly set the deprecated value.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
