### PR TITLE
config: add TRUSTED_HOSTS for Flask v3 compatibility

### DIFF
--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -393,6 +393,7 @@ Invenio basic configuration variables
 {{- define "invenio.configBase" -}}
 INVENIO_ACCOUNTS_SESSION_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/1'
 INVENIO_APP_ALLOWED_HOSTS: '["{{ include "invenio.hostname" $ }}"]'
+INVENIO_TRUSTED_HOSTS: '["{{ include "invenio.hostname" $ }}"]'
 INVENIO_CACHE_REDIS_HOST: '{{ include "invenio.redis.hostname" . }}'
 INVENIO_CACHE_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/0'
 INVENIO_CELERY_RESULT_BACKEND: 'redis://{{ include "invenio.redis.hostname" . }}:6379/2'


### PR DESCRIPTION
I am not simply replacing `INVENIO_APP_ALLOWED_HOSTS` to keep compatibility with v12 while allowing v13 😉 