### PR TITLE
values: allow templates values in extraEnvFrom

### DIFF
--- a/charts/invenio/templates/flower/deployment.yaml
+++ b/charts/invenio/templates/flower/deployment.yaml
@@ -48,14 +48,9 @@ spec:
                   name: {{ .Values.flower.secret_name }}
                   key: FLOWER_BASIC_AUTH_CREDENTIALS
             {{- include "invenio.config.queue" . | nindent 12 }}
-          {{- if (or .Values.invenio.extraEnvFrom .Values.flower.extraEnvFrom) }}
+          {{- with .Values.flower.extraEnvFrom }}
           envFrom:
-            {{- with .Values.invenio.extraEnvFrom }}
-            {{- . | toYaml | nindent 12 }}
-            {{- end }}
-            {{- with .Values.flower.extraEnvFrom }}
-            {{- . | toYaml | nindent 12 }}
-            {{- end }}
+            {{- tpl (. | toYaml) $ | nindent 12 }}
           {{- end }}
           resources: {{- toYaml .Values.flower.resources | nindent 12 }}
           volumeMounts:

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -41,10 +41,10 @@ spec:
         - secretRef:
             name: {{ include "invenio.secretName" . }}
         {{- with .Values.invenio.extraEnvFrom }}
-        {{- . | toYaml | nindent 8 }}
+        {{- tpl (. | toYaml) $ | nindent 8 }}
         {{- end }}
         {{- with .Values.web.extraEnvFrom }}
-        {{- . | toYaml | nindent 8 }}
+        {{- tpl (. | toYaml) $ | nindent 8 }}
         {{- end }}
         env:
         - name: TZ

--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -55,10 +55,10 @@ spec:
         - secretRef:
             name: {{ include "invenio.secretName" . }}
         {{- with .Values.invenio.extraEnvFrom }}
-        {{- . | toYaml | nindent 8 }}
+        {{- tpl (. | toYaml) $ | nindent 8 }}
         {{- end }}
         {{- with .Values.workerBeat.extraEnvFrom }}
-        {{- . | toYaml | nindent 8 }}
+        {{- tpl (. | toYaml) $ | nindent 8 }}
         {{- end }}
         env:
         - name: TZ

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -44,10 +44,10 @@ spec:
             - secretRef:
                 name: {{ include "invenio.secretName" . }}
             {{- with .Values.invenio.extraEnvFrom }}
-            {{- . | toYaml | nindent 12 }}
+            {{- tpl (. | toYaml) $ | nindent 12 }}
             {{- end }}
             {{- with .Values.worker.extraEnvFrom }}
-            {{- . | toYaml | nindent 12 }}
+            {{- tpl (. | toYaml) $ | nindent 12 }}
             {{- end }}
           env:
           - name: TZ

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -152,7 +152,7 @@ invenio:
   ##
   extraEnvVars: []
   uwsgiExtraConfig: {}
-  ## @param invenio.extraEnvFrom Extra secretRef or configMapRef for the `envFrom` field in all Invenio containers
+  ## @param invenio.extraEnvFrom Extra secretRef or configMapRef for the `envFrom` field in all Invenio containers (templated).
   ##
   extraEnvFrom: []
     # - secretRef:
@@ -367,7 +367,7 @@ web:
     capabilities:
       drop:
         - ALL
-  ## @param web.extraEnvFrom Extra secretRef or configMapRef for the `envFrom` field in the web container
+  ## @param web.extraEnvFrom Extra secretRef or configMapRef for the `envFrom` field in the web container (templated).
   ##
   extraEnvFrom: []
     # - secretRef:
@@ -420,7 +420,7 @@ worker:
     capabilities:
       drop:
         - ALL
-  ## @param worker.extraEnvFrom Extra secretRef or configMapRef for the `envFrom` field in the worker container
+  ## @param worker.extraEnvFrom Extra secretRef or configMapRef for the `envFrom` field in the worker container (templated).
   ##
   extraEnvFrom: []
     # - secretRef:
@@ -485,7 +485,7 @@ workerBeat:
     runAsGroup: 1000
     seccompProfile:
       type: "RuntimeDefault"
-  ## @param workerBeat.extraEnvFrom Extra secretRef or configMapRef for the `envFrom` field in the worker-beat container
+  ## @param workerBeat.extraEnvFrom Extra secretRef or configMapRef for the `envFrom` field in the worker-beat container (templated).
   ##
   extraEnvFrom: []
     # - secretRef:
@@ -586,7 +586,7 @@ flower:
     # limits:
     #   memory: 250Mi
     #   cpu: 0.1
-  ## @param flower.extraEnvFrom Extra secretRef or configMapRef for the `envFrom` field in the flower container
+  ## @param flower.extraEnvFrom Extra secretRef or configMapRef for the `envFrom` field in the flower container (templated).
   ##
   extraEnvFrom: []
     # - secretRef:


### PR DESCRIPTION
Flower has nothing to do with Invenio. Adding the `invenio.extraEnvFrom` is unnecessary and can potentially cause some leakage.