### PR TITLE
docs: sslSecretName -> tlsSecretNameOverride in k8s docs

### DIFF
--- a/README-Kubernetes.md
+++ b/README-Kubernetes.md
@@ -16,7 +16,7 @@ is pulled, you have to define an `imagePullSecret`:
 ```bash
 kubectl create secret docker-registry regsecret \
   --docker-server=DOCKERHOST_CHANGEME \
-  --docker-username=DOCKERUSER_CHANGEME \ 
+  --docker-username=DOCKERUSER_CHANGEME \
   --docker-password=DOCKERPASSWORD_CHANGEME \
   --docker-email=EMAIL_CHANGE_ME \
   --namespace invenio
@@ -38,7 +38,7 @@ Before installing you need to configure a few things in a
 
 ```yaml
 ingress:
-  sslSecretName: your-ssl-secret
+  tlsSecretNameOverride: your-ssl-secret
 ```
 
 The ingress is configured using the following variables:
@@ -47,7 +47,7 @@ Parameter | Description | Default
 ----------|-------------|--------
 `ingress.enabled` | Whether to enable ingress | `true`
 `ingress.class` | Class of the ingress if enabled | `nginx-internal`
-`ingress.sslSecretName` | The ingress ssl secret for HTTPS | `your-ssl-secret`
+`ingress.tlsSecretNameOverride` | The ingress ssl secret for HTTPS | `your-ssl-secret`
 
 ## Instance setup
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

The name of this property was changed in 97fd16598e02765d1dfb01baa1eb96c33e361891  but the Kubernetes doc was not updated to match.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
