### PR TITLE
nginx: remove robots.txt static location

### DIFF
--- a/charts/invenio/templates/nginx-configmap.yaml
+++ b/charts/invenio/templates/nginx-configmap.yaml
@@ -230,12 +230,6 @@ data:
           add_header X-Content-Type-Options nosniff;
         }
 
-        # Robots.txt file is served by nginx.
-        location /robots.txt {
-          alias {{ .Values.nginx.assets.location }}/robots.txt;
-          autoindex off;
-        }
-
 {{ .Values.nginx.extra_server_config | indent 8 }}
 {{ tpl .Values.nginx.extraServerConfig $ | indent 8 }}
 


### PR DESCRIPTION
* With the addition of the new Invenio-Sitemap module, the ``robots.txt`` file is no longer static, it's a template.

Check https://github.com/inveniosoftware/invenio-app-rdm/commit/6a0bd02892b7ba9feaa5a159a8dfb0f66e288ae8#diff-f842f0243e36637687a93857155ca64bd0f8b594394e19d1fb85f30b062ad558