### PR TITLE
Fix pod annotation/label templates

### DIFF
--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -34,11 +34,11 @@ spec:
         checksum/nginx-configmap: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
         checksum/uwsgi-configmap: {{ include (print $.Template.BasePath "/uwsgi-configmap.yaml") . | sha256sum }}
         {{- with .Values.web.podAnnotations }}
-          {{- tpl (toYaml .) | nindent 8 }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       labels:
         {{- with .Values.web.podLabels }}
-          {{- tpl (toYaml .) | nindent 8 }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         app.kubernetes.io/component: web
     spec:

--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -30,13 +30,13 @@ spec:
     metadata:
       annotations:
         {{- with .Values.workerBeat.podAnnotations }}
-          {{- tpl (toYaml .) | nindent 8 }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         app.kubernetes.io/component: worker-beat
         checksum/invenio-config: {{ include (print $.Template.BasePath "/invenio-configmap.yaml") . | sha256sum }}
       labels:
         {{- with .Values.workerBeat.podLabels }}
-          {{- tpl (toYaml .) | nindent 8 }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         app.kubernetes.io/component: worker-beat
     spec:

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -30,13 +30,13 @@ spec:
     metadata:
       annotations:
         {{- with .Values.worker.podAnnotations }}
-          {{- tpl (toYaml .) | nindent 8 }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         app.kubernetes.io/component: worker
         checksum/invenio-config: {{ include (print $.Template.BasePath "/invenio-configmap.yaml") . | sha256sum }}
       labels:
         {{- with .Values.worker.podLabels }}
-          {{- tpl (toYaml .) | nindent 8 }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         app.kubernetes.io/component: worker
     spec:


### PR DESCRIPTION
### Description

When using pod annotations or labels, rendering of the chart fails with
```
Helm Error: template: (...) executing "invenio/charts/invenio/templates/(...)" at <tpl>: wrong number of args for tpl: want 2 got 1
```
due to a missing context parameter.

Btw, below links from the PR template are outdated ;)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
