### PR TITLE
feat: Enable more granual configuration of `opensearchExternal`

### DIFF
--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -264,7 +264,10 @@ Return the proper Invenio image name
   {{- if not .Values.opensearch.enabled }}
     {{- with $.Values.opensearchExternal -}}
       {{- if .auth.enabled -}}
-        {{- $params = append $params "'http_auth': ('$(OPENSEARCH_USERNAME)', '$(OPENSEARCH_PASSWORD)')" -}}
+        {{- $username := .auth.usernameEnv.name -}}
+        {{- $password := .auth.passwordEnv.name -}}
+        {{- $credentials := printf "'http_auth': ('$(%s)','$(%s)')" $username $password -}}
+        {{- $params = append $params $credentials -}}
       {{- end -}}
       {{- if .encryption.enabled -}}
         {{- $params = append $params "'use_ssl': True" -}}

--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -286,15 +286,15 @@ Return the proper Invenio image name
   This template renders the extra environment variables for opensearchExternal
 */}}
 {{- define "invenio.opensearch.env" -}}
-{{- if not .Values.opensearch.enabled -}}
-{{- with $.Values.opensearchExternal -}}
-{{- if (dig "auth" "enabled" false .) -}}
-{{- $u := required "Missing .Values.opensearchExternal.auth.usernameEnv" .auth.usernameEnv -}}
-{{- $p := required "Missing .Values.opensearchExternal.auth.passwordEnv" .auth.passwordEnv -}}
-{{- list $u $p | toYaml -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+  {{- if not .Values.opensearch.enabled -}}
+    {{- with $.Values.opensearchExternal -}}
+      {{- if (dig "auth" "enabled" false .) -}}
+        {{- $u := required "Missing .Values.opensearchExternal.auth.usernameEnv" .auth.usernameEnv -}}
+        {{- $p := required "Missing .Values.opensearchExternal.auth.passwordEnv" .auth.passwordEnv -}}
+        {{- list $u $p | toYaml -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 ##############     Extra volumeMounts for opensearchExternal     ##############

--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -274,7 +274,7 @@ Return the proper Invenio image name
         {{- $params = append $params (printf "'ca_certs': '%s'" .encryption.caCert.mountPath) -}}
       {{- end -}}
       {{- if .port -}}
-        {{- $params = append $params (printf "'port': '%d'" .port) -}}
+        {{- $params = append $params (printf "'port': '%v'" .port) -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}

--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -255,6 +255,29 @@ Return the proper Invenio image name
   {{- end }}
 {{- end -}}
 
+#########################     SEARCH_HOSTS string     #########################
+{{/*
+  This template renders the string value for the [INVENIO_]SEARCH_HOSTS environment variable.
+*/}}
+{{- define "invenio.searchHostsString" -}}
+  {{- $params := list (printf "'host': '%s'" (include "invenio.opensearch.hostname" .)) -}}
+  {{- if not .Values.opensearch.enabled }}
+    {{- with $.Values.opensearchExternal -}}
+      {{- if .auth.enabled -}}
+        {{- $params = append $params "'http_auth': ('$(OPENSEARCH_USERNAME)', '$(OPENSEARCH_PASSWORD)')" -}}
+      {{- end -}}
+      {{- if .encryption.enabled -}}
+        {{- $params = append $params "'use_ssl': True" -}}
+        {{- $params = append $params (printf "'ca_certs': '%s'" .encryption.caCert.mountPath) -}}
+      {{- end -}}
+      {{- if .port -}}
+        {{- $params = append $params (printf "'port': '%d'" .port) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- printf "[{%s}]" (join "," $params) -}}
+{{- end -}}
+
 #########################     PostgreSQL connection configuration     #########################
 {{/*
   This template renders the username used for the PostgreSQL instance.
@@ -399,7 +422,7 @@ INVENIO_CELERY_RESULT_BACKEND: 'redis://{{ include "invenio.redis.hostname" . }}
 INVENIO_IIIF_CACHE_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/0'
 INVENIO_RATELIMIT_STORAGE_URI: 'redis://{{ include "invenio.redis.hostname" . }}:6379/3'
 INVENIO_COMMUNITIES_IDENTITIES_CACHE_REDIS_URL: 'redis://{{ include "invenio.redis.hostname" . }}:6379/4'
-INVENIO_SEARCH_HOSTS: {{ printf "[{'host': '%s'}]" (include "invenio.opensearch.hostname" .) | quote }}
+INVENIO_SEARCH_HOSTS: {{ include "invenio.searchHostsString" $ | quote }}
 INVENIO_SITE_HOSTNAME: '{{ include "invenio.hostname" $ }}'
 INVENIO_SITE_UI_URL: 'https://{{ include "invenio.hostname" $ }}'
 INVENIO_SITE_API_URL: 'https://{{ include "invenio.hostname" $ }}/api'

--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -263,13 +263,13 @@ Return the proper Invenio image name
   {{- $params := list (printf "'host': '%s'" (include "invenio.opensearch.hostname" .)) -}}
   {{- if not .Values.opensearch.enabled }}
     {{- with $.Values.opensearchExternal -}}
-      {{- if .auth.enabled -}}
+      {{- if (dig "auth" "enabled" false .) -}}
         {{- $username := .auth.usernameEnv.name -}}
         {{- $password := .auth.passwordEnv.name -}}
         {{- $credentials := printf "'http_auth': ('$(%s)','$(%s)')" $username $password -}}
         {{- $params = append $params $credentials -}}
       {{- end -}}
-      {{- if .encryption.enabled -}}
+      {{- if (dig "encryption" "enabled" false .) -}}
         {{- $params = append $params "'use_ssl': True" -}}
         {{- $params = append $params (printf "'ca_certs': '%s'" .encryption.caCert.mountPath) -}}
       {{- end -}}
@@ -288,7 +288,7 @@ Return the proper Invenio image name
 {{- define "invenio.opensearch.env" -}}
 {{- if not .Values.opensearch.enabled -}}
 {{- with $.Values.opensearchExternal -}}
-{{- if .auth.enabled -}}
+{{- if (dig "auth" "enabled" false .) -}}
 {{ list (required "Missing .Values.opensearchExternal.auth.usernameEnv" .auth.usernameEnv) | toYaml }}
 {{ list (required "Missing .Values.opensearchExternal.auth.passwordEnv" .auth.passwordEnv) | toYaml }}
 {{- end -}}

--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -289,8 +289,9 @@ Return the proper Invenio image name
 {{- if not .Values.opensearch.enabled -}}
 {{- with $.Values.opensearchExternal -}}
 {{- if (dig "auth" "enabled" false .) -}}
-{{ list (required "Missing .Values.opensearchExternal.auth.usernameEnv" .auth.usernameEnv) | toYaml }}
-{{ list (required "Missing .Values.opensearchExternal.auth.passwordEnv" .auth.passwordEnv) | toYaml }}
+{{- $u := required "Missing .Values.opensearchExternal.auth.usernameEnv" .auth.usernameEnv -}}
+{{- $p := required "Missing .Values.opensearchExternal.auth.passwordEnv" .auth.passwordEnv -}}
+{{- list $u $p | toYaml -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -293,6 +293,40 @@ Return the proper Invenio image name
 {{- end -}}
 {{- end -}}
 
+##############     Extra volumeMounts for opensearchExternal     ##############
+{{/*
+  This template renders the extra volumeMounts needed for opensearchExternal
+*/}}
+{{- define "invenio.opensearch.volumeMounts" -}}
+{{- if not .Values.opensearch.enabled -}}
+{{- with $.Values.opensearchExternal.encryption -}}
+{{- if .enabled -}}
+- name: opensearch-ca
+  mountPath: {{ required "Missing .Values.opensearchExternal.encryption.caCert.mountPath" .caCert.mountPath }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+#################     Extra volumes for opensearchExternal     #################
+{{/*
+  This template renders the extra volumes needed for opensearchExternal
+*/}}
+{{- define "invenio.opensearch.volumes" -}}
+{{- if not .Values.opensearch.enabled -}}
+{{- with $.Values.opensearchExternal.encryption -}}
+{{- if .enabled -}}
+- name: opensearch-ca
+  secret:
+    secretName: {{ required "Missing .Values.opensearchExternal.encryption.caCert.secretName" .caCert.secretName }}
+    items:
+      - key: {{ required "Missing .Values.opensearchExternal.encryption.caCert.secretName" .caCert.secretKey }}
+        path: ca.crt
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 #########################     PostgreSQL connection configuration     #########################
 {{/*
   This template renders the username used for the PostgreSQL instance.

--- a/charts/invenio/templates/_helpers.tpl
+++ b/charts/invenio/templates/_helpers.tpl
@@ -278,6 +278,21 @@ Return the proper Invenio image name
   {{- printf "[{%s}]" (join "," $params) -}}
 {{- end -}}
 
+###################     Extra env for opensearchExternal     ###################
+{{/*
+  This template renders the extra environment variables for opensearchExternal
+*/}}
+{{- define "invenio.opensearch.env" -}}
+{{- if not .Values.opensearch.enabled -}}
+{{- with $.Values.opensearchExternal -}}
+{{- if .auth.enabled -}}
+{{ list (required "Missing .Values.opensearchExternal.auth.usernameEnv" .auth.usernameEnv) | toYaml }}
+{{ list (required "Missing .Values.opensearchExternal.auth.passwordEnv" .auth.passwordEnv) | toYaml }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 #########################     PostgreSQL connection configuration     #########################
 {{/*
   This template renders the username used for the PostgreSQL instance.

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -84,6 +84,7 @@ spec:
           value: {{ required "Missing .Values.global.timezone" .Values.global.timezone }}
         {{- include "invenio.config.queue" . | nindent 8 }}
         {{- include "invenio.config.database" . | nindent 8 }}
+        {{- include "invenio.opensearch.env" . | nindent 8 }}
         {{- with .Values.invenio.extraEnvVars }}
         {{-  toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -140,6 +140,7 @@ spec:
             subPath: "{{ $key }}"
             {{- end }}
           {{- end }}
+          {{- include "invenio.opensearch.volumeMounts" . | nindent 10 }}
           {{- with .Values.invenio.extraVolumeMounts }}
           {{- tpl (toYaml .) $ | nindent 10 }}
           {{- end }}
@@ -300,6 +301,7 @@ spec:
         configMap:
           name: "{{ include "invenio.fullname" . }}-vocabularies"
       {{- end }}
+      {{- include "invenio.opensearch.volumes" . | nindent 6 }}
       {{- with .Values.invenio.extraVolumes }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -84,7 +84,7 @@ spec:
           value: {{ required "Missing .Values.global.timezone" .Values.global.timezone }}
         {{- include "invenio.config.queue" . | nindent 8 }}
         {{- include "invenio.config.database" . | nindent 8 }}
-        {{- include "invenio.opensearch.env" . | nindent 8 | trim }}
+        {{- include "invenio.opensearch.env" . | nindent 8 }}
         {{- with .Values.invenio.extraEnvVars }}
         {{-  toYaml . | nindent 8 }}
         {{- end }}
@@ -140,7 +140,7 @@ spec:
             subPath: "{{ $key }}"
             {{- end }}
           {{- end }}
-          {{- include "invenio.opensearch.volumeMounts" . | nindent 10 | trim }}
+          {{- include "invenio.opensearch.volumeMounts" . | nindent 10 }}
           {{- with .Values.invenio.extraVolumeMounts }}
           {{- tpl (toYaml .) $ | nindent 10 }}
           {{- end }}
@@ -301,7 +301,7 @@ spec:
         configMap:
           name: "{{ include "invenio.fullname" . }}-vocabularies"
       {{- end }}
-      {{- include "invenio.opensearch.volumes" . | nindent 6 | trim }}
+      {{- include "invenio.opensearch.volumes" . | nindent 6 }}
       {{- with .Values.invenio.extraVolumes }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -84,7 +84,7 @@ spec:
           value: {{ required "Missing .Values.global.timezone" .Values.global.timezone }}
         {{- include "invenio.config.queue" . | nindent 8 }}
         {{- include "invenio.config.database" . | nindent 8 }}
-        {{- include "invenio.opensearch.env" . | nindent 8 }}
+        {{- include "invenio.opensearch.env" . | nindent 8 | trim }}
         {{- with .Values.invenio.extraEnvVars }}
         {{-  toYaml . | nindent 8 }}
         {{- end }}
@@ -140,7 +140,7 @@ spec:
             subPath: "{{ $key }}"
             {{- end }}
           {{- end }}
-          {{- include "invenio.opensearch.volumeMounts" . | nindent 10 }}
+          {{- include "invenio.opensearch.volumeMounts" . | nindent 10 | trim }}
           {{- with .Values.invenio.extraVolumeMounts }}
           {{- tpl (toYaml .) $ | nindent 10 }}
           {{- end }}
@@ -301,7 +301,7 @@ spec:
         configMap:
           name: "{{ include "invenio.fullname" . }}-vocabularies"
       {{- end }}
-      {{- include "invenio.opensearch.volumes" . | nindent 6 }}
+      {{- include "invenio.opensearch.volumes" . | nindent 6 | trim }}
       {{- with .Values.invenio.extraVolumes }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -104,6 +104,7 @@ spec:
           value: {{ required "Missing .Values.global.timezone" .Values.global.timezone }}
         {{- include "invenio.config.queue" . | nindent 8 }}
         {{- include "invenio.config.database" . | nindent 8}}
+        {{- include "invenio.opensearch.env" . | nindent 8 }}
         {{- with .Values.invenio.extraEnvVars }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -82,7 +82,7 @@ spec:
           subPath: "{{ $key }}"
           {{- end }}
         {{- end }}
-        {{- include "invenio.opensearch.volumeMounts" . | nindent 8 }}
+        {{- include "invenio.opensearch.volumeMounts" . | nindent 8 | trim }}
         {{- with .Values.invenio.extraVolumeMounts }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
@@ -105,7 +105,7 @@ spec:
           value: {{ required "Missing .Values.global.timezone" .Values.global.timezone }}
         {{- include "invenio.config.queue" . | nindent 8 }}
         {{- include "invenio.config.database" . | nindent 8}}
-        {{- include "invenio.opensearch.env" . | nindent 8 }}
+        {{- include "invenio.opensearch.env" . | nindent 8 | trim }}
         {{- with .Values.invenio.extraEnvVars }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -143,7 +143,7 @@ spec:
         configMap:
           name: "{{ include "invenio.fullname" . }}-vocabularies"
       {{- end }}
-      {{- include "invenio.opensearch.volumes" . | nindent 6 }}
+      {{- include "invenio.opensearch.volumes" . | nindent 6 | trim }}
       {{- with .Values.invenio.extraVolumes }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -82,7 +82,7 @@ spec:
           subPath: "{{ $key }}"
           {{- end }}
         {{- end }}
-        {{- include "invenio.opensearch.volumeMounts" . | nindent 8 | trim }}
+        {{- include "invenio.opensearch.volumeMounts" . | nindent 8 }}
         {{- with .Values.invenio.extraVolumeMounts }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
@@ -105,7 +105,7 @@ spec:
           value: {{ required "Missing .Values.global.timezone" .Values.global.timezone }}
         {{- include "invenio.config.queue" . | nindent 8 }}
         {{- include "invenio.config.database" . | nindent 8}}
-        {{- include "invenio.opensearch.env" . | nindent 8 | trim }}
+        {{- include "invenio.opensearch.env" . | nindent 8 }}
         {{- with .Values.invenio.extraEnvVars }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -143,7 +143,7 @@ spec:
         configMap:
           name: "{{ include "invenio.fullname" . }}-vocabularies"
       {{- end }}
-      {{- include "invenio.opensearch.volumes" . | nindent 6 | trim }}
+      {{- include "invenio.opensearch.volumes" . | nindent 6 }}
       {{- with .Values.invenio.extraVolumes }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -82,6 +82,7 @@ spec:
           subPath: "{{ $key }}"
           {{- end }}
         {{- end }}
+        {{- include "invenio.opensearch.volumeMounts" . | nindent 8 }}
         {{- with .Values.invenio.extraVolumeMounts }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
@@ -142,6 +143,7 @@ spec:
         configMap:
           name: "{{ include "invenio.fullname" . }}-vocabularies"
       {{- end }}
+      {{- include "invenio.opensearch.volumes" . | nindent 6 }}
       {{- with .Values.invenio.extraVolumes }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -85,7 +85,7 @@ spec:
             value: {{ required "Missing .Values.global.timezone" .Values.global.timezone }}
           {{- include "invenio.config.queue" . | nindent 10 }}
           {{- include "invenio.config.database" . | nindent 10 }}
-          {{- include "invenio.opensearch.env" . | nindent 10 | trim }}
+          {{- include "invenio.opensearch.env" . | nindent 10 }}
           {{- with .Values.invenio.extraEnvVars }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -132,7 +132,7 @@ spec:
               subPath: "{{ $key }}"
               {{- end }}
             {{- end }}
-            {{- include "invenio.opensearch.volumeMounts" . | nindent 12 | trim }}
+            {{- include "invenio.opensearch.volumeMounts" . | nindent 12 }}
             {{- with .Values.invenio.extraVolumeMounts }}
             {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
@@ -191,7 +191,7 @@ spec:
           configMap:
             name: "{{ include "invenio.fullname" . }}-vocabularies"
         {{- end }}
-        {{- include "invenio.opensearch.volumes" . | nindent 8 | trim }}
+        {{- include "invenio.opensearch.volumes" . | nindent 8 }}
         {{- with .Values.invenio.extraVolumes }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -131,6 +131,7 @@ spec:
               subPath: "{{ $key }}"
               {{- end }}
             {{- end }}
+            {{- include "invenio.opensearch.volumeMounts" . | nindent 12 }}
             {{- with .Values.invenio.extraVolumeMounts }}
             {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
@@ -189,6 +190,7 @@ spec:
           configMap:
             name: "{{ include "invenio.fullname" . }}-vocabularies"
         {{- end }}
+        {{- include "invenio.opensearch.volumes" . | nindent 8 }}
         {{- with .Values.invenio.extraVolumes }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -85,6 +85,7 @@ spec:
             value: {{ required "Missing .Values.global.timezone" .Values.global.timezone }}
           {{- include "invenio.config.queue" . | nindent 10 }}
           {{- include "invenio.config.database" . | nindent 10 }}
+          {{- include "invenio.opensearch.env" . | nindent 10 }}
           {{- with .Values.invenio.extraEnvVars }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -85,7 +85,7 @@ spec:
             value: {{ required "Missing .Values.global.timezone" .Values.global.timezone }}
           {{- include "invenio.config.queue" . | nindent 10 }}
           {{- include "invenio.config.database" . | nindent 10 }}
-          {{- include "invenio.opensearch.env" . | nindent 10 }}
+          {{- include "invenio.opensearch.env" . | nindent 10 | trim }}
           {{- with .Values.invenio.extraEnvVars }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -132,7 +132,7 @@ spec:
               subPath: "{{ $key }}"
               {{- end }}
             {{- end }}
-            {{- include "invenio.opensearch.volumeMounts" . | nindent 12 }}
+            {{- include "invenio.opensearch.volumeMounts" . | nindent 12 | trim }}
             {{- with .Values.invenio.extraVolumeMounts }}
             {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
@@ -191,7 +191,7 @@ spec:
           configMap:
             name: "{{ include "invenio.fullname" . }}-vocabularies"
         {{- end }}
-        {{- include "invenio.opensearch.volumes" . | nindent 8 }}
+        {{- include "invenio.opensearch.volumes" . | nindent 8 | trim }}
         {{- with .Values.invenio.extraVolumes }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -1286,8 +1286,15 @@ opensearch:
 opensearchExternal: {}
   # auth:
   #   enabled: false
-  #   usernameEnvValue: ""
-  #   passwordEnvValue: ""
+  #   usernameEnv:
+  #     name: OPENSEARCH_USERNAME
+  #     value: admin
+  #   passwordEnv:
+  #     name: OPENSEARCH_PASSWORD
+  #     valueFrom:
+  #       secretKeyRef:
+  #         key: password
+  #         name: opensearch-admin-password
   # encryption:
   #   enabled: false
   #   caCert:

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -1281,9 +1281,9 @@ opensearch:
     ##
     repository: bitnamilegacy/os-shell  # Work-around until we've migrated away from Bitnami.
 
-## @param externalOpensearch External Opensearch configuration
+## @param opensearchExternal External Opensearch configuration
 ## All of these values are only used when opensearch.enabled is set to false
-externalOpensearch: {}
+opensearchExternal: {}
 
 ## @secion Logstash configuration
 ## TODO: review content and possibly remove

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -1284,6 +1284,18 @@ opensearch:
 ## @param opensearchExternal External Opensearch configuration
 ## All of these values are only used when opensearch.enabled is set to false
 opensearchExternal: {}
+  # auth:
+  #   enabled: false
+  #   usernameEnvValue: ""
+  #   passwordEnvValue: ""
+  # encryption:
+  #   enabled: false
+  #   caCert:
+  #     mountPath: /etc/opensearch/certs
+  #     secretKey: ca.crt
+  #     secretName: opensearch-ca
+  # hostname: opensearch
+  # port: 9200
 
 ## @secion Logstash configuration
 ## TODO: review content and possibly remove

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -1283,6 +1283,15 @@ opensearch:
 
 ## @param opensearchExternal External Opensearch configuration
 ## All of these values are only used when opensearch.enabled is set to false
+## @extra opensearchExternal.auth.enabled Enable credentials for http_auth to the OpenSearch endpoint.
+## @extra opensearchExternal.auth.usernameEnv Stanza for the username variable for authentication to the OpenSearch endpoint. Same format as EnvVar items in the containers[].env field.
+## @extra opensearchExternal.auth.passwordEnv Stanza for the password variable for authentication to the OpenSearch endpoint. Same format as EnvVar items in the containers[].env field.
+## @extra opensearchExternal.encryption.enabled Enables TLS encryption for the connection to the OpenSearch endpoint.
+## @extra opensearchExternal.encryption.caCert.mountPath Mount path for the OpenSearch endpoint's CA certificate.
+## @extra opensearchExternal.encryption.caCert.secretKey The key in the secret containing the OpenSearch endpoint's CA certificate.
+## @extra opensearchExternal.encryption.caCert.secretName The name of the secret containing the OpenSearch endpoint's CA certificate.
+## @extra opensearchExternal.hostname The hostname of the OpenSearch endpoint.
+## @extra opensearchExternal.port The port number of the OpenSearch endpoint.
 opensearchExternal: {}
   # auth:
   #   enabled: false


### PR DESCRIPTION
### Description

I recently configured our Invenio instance to use an externally deployed OpenSearch cluster. I found that the required configuration was a bit fiddly, so I think others would find it useful if it was better integrated in the Helm chart.

This change includes:

- Fixing a typo: `externalOpensearch` --> `opensearchExternal`
- Introducing some new values to let users configure access to authenticated OpenSearch clusters with TLS and custom port number.
- Dynamically building the `INVENIO_SEARCH_HOSTS` string.
- Mounting CA cert.
- Flexible methods to set credentials in plain text or via secrets.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
