### PR TITLE
feat: add affinity configuration for web and worker pods

### DIFF
--- a/charts/invenio/ci/full-values.yaml
+++ b/charts/invenio/ci/full-values.yaml
@@ -61,6 +61,18 @@ web:
     scaler_cpu_utilization: 65
     max_web_replicas: 10
     min_web_replicas: 2
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - web
+            topologyKey: kubernetes.io/hostname
   nodeSelector:
     node-role: web
   tolerations:
@@ -85,6 +97,18 @@ web:
           maxUnavailable: 0
 
 worker:
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - worker
+            topologyKey: kubernetes.io/hostname
   nodeSelector:
     node-role: worker
   tolerations:
@@ -98,6 +122,18 @@ worker:
     ci-test: "true"
 
 workerBeat:
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - worker-beat
+            topologyKey: kubernetes.io/hostname
   nodeSelector:
     node-role: worker-beat
   tolerations:

--- a/charts/invenio/templates/web-deployment.yaml
+++ b/charts/invenio/templates/web-deployment.yaml
@@ -50,6 +50,10 @@ spec:
         app.kubernetes.io/component: web
     spec:
       terminationGracePeriodSeconds: {{ .Values.web.terminationGracePeriodSeconds }}
+      {{- with .Values.web.affinity }}
+      affinity:
+        {{- tpl (toYaml .) $ | nindent 8 -}}
+      {{- end }}
       {{- with .Values.web.nodeSelector }}
       nodeSelector:
         {{- tpl (toYaml .) $ | nindent 8 -}}

--- a/charts/invenio/templates/worker-beat-deployment.yaml
+++ b/charts/invenio/templates/worker-beat-deployment.yaml
@@ -47,6 +47,10 @@ spec:
         {{- end }}
         app.kubernetes.io/component: worker-beat
     spec:
+      {{- with .Values.workerBeat.affinity }}
+      affinity:
+        {{- tpl (toYaml .) $ | nindent 8 -}}
+      {{- end }}
       {{- with .Values.workerBeat.nodeSelector }}
       nodeSelector:
         {{- tpl (toYaml .) $ | nindent 8 -}}

--- a/charts/invenio/templates/worker-deployment.yaml
+++ b/charts/invenio/templates/worker-deployment.yaml
@@ -47,6 +47,10 @@ spec:
         {{- end }}
         app.kubernetes.io/component: worker
     spec:
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- tpl (toYaml .) $ | nindent 8 -}}
+      {{- end }}
       {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- tpl (toYaml .) $ | nindent 8 -}}

--- a/charts/invenio/tests/web-deployment_test.yaml
+++ b/charts/invenio/tests/web-deployment_test.yaml
@@ -86,6 +86,30 @@ tests:
             value: my-value
         template: templates/web-deployment.yaml
 
+  - it: adds affinity when set
+    set:
+      web.affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/component
+                      operator: In
+                      values:
+                        - web
+                topologyKey: kubernetes.io/hostname
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 100
+        template: templates/web-deployment.yaml
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
+          value: kubernetes.io/hostname
+        template: templates/web-deployment.yaml
+
   - it: omits shared-volume when persistence is disabled
     set:
       persistence.enabled: false

--- a/charts/invenio/tests/worker-beat-deployment_test.yaml
+++ b/charts/invenio/tests/worker-beat-deployment_test.yaml
@@ -59,6 +59,30 @@ tests:
           path: spec.template.metadata.annotations["prometheus.io/scrape"]
         template: templates/worker-beat-deployment.yaml
 
+  - it: adds affinity when set
+    set:
+      workerBeat.affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/component
+                      operator: In
+                      values:
+                        - worker-beat
+                topologyKey: kubernetes.io/hostname
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 100
+        template: templates/worker-beat-deployment.yaml
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
+          value: kubernetes.io/hostname
+        template: templates/worker-beat-deployment.yaml
+
   - it: adds extra env vars
     set:
       workerBeat.extraEnvVars:

--- a/charts/invenio/tests/worker-deployment_test.yaml
+++ b/charts/invenio/tests/worker-deployment_test.yaml
@@ -74,6 +74,30 @@ tests:
             value: my-value
         template: templates/worker-deployment.yaml
 
+  - it: adds affinity when set
+    set:
+      worker.affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/component
+                      operator: In
+                      values:
+                        - worker
+                topologyKey: kubernetes.io/hostname
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 100
+        template: templates/worker-deployment.yaml
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
+          value: kubernetes.io/hostname
+        template: templates/worker-deployment.yaml
+
   - it: adds deployment annotations when set
     set:
       worker.deployment.annotations:

--- a/charts/invenio/values.yaml
+++ b/charts/invenio/values.yaml
@@ -429,6 +429,26 @@ web:
   ## @param web.podAnnotations Add extra annotations to the Invenio web pods
   ##
   podAnnotations: {}
+  ## @param web.affinity Affinity rules for web pods assignment
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  ## Useful for spreading replicas across nodes to improve availability.
+  ## Example — prefer scheduling web pods on different nodes:
+  ##
+  ##   affinity:
+  ##     podAntiAffinity:
+  ##       preferredDuringSchedulingIgnoredDuringExecution:
+  ##         - weight: 100
+  ##           podAffinityTerm:
+  ##             labelSelector:
+  ##               matchExpressions:
+  ##                 - key: app.kubernetes.io/component
+  ##                   operator: In
+  ##                   values:
+  ##                     - web
+  ##             topologyKey: kubernetes.io/hostname
+  ##
+  affinity: {}
   ## @param web.nodeSelector Node labels for web pods assignment
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   ##
@@ -623,6 +643,10 @@ worker:
   ## @param worker.podAnnotations Add extra annotations to the Invenio worker pods
   ##
   podAnnotations: {}
+  ## @param worker.affinity Affinity rules for worker pods assignment
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
   ## @param worker.nodeSelector Node labels for worker pods assignment
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   ##
@@ -760,6 +784,10 @@ workerBeat:
   ## @param workerBeat.podAnnotations Add extra annotations to the Invenio workerBeat pods
   ##
   podAnnotations: {}
+  ## @param workerBeat.affinity Affinity rules for workerBeat pods assignment
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
   ## @param workerBeat.nodeSelector Node labels for workerBeat pods assignment
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   ##


### PR DESCRIPTION
Allows users to configure pod affinity/anti-affinity rules for web, and worker deployments. This enables spreading replicas across nodes to improve availability

---

I based this branch on #247 to start adding tests right away.